### PR TITLE
[ECO-2165] Add `--bind-to` to the default `aptos node` args in the `cloud-infra/aptos-cli`

### DIFF
--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -55,6 +55,9 @@ COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
 
 STOPSIGNAL SIGKILL
 
+# By default, run the localnet with the indexer API enabled and request to
+# bind to all interfaces. Without this flag, the node may not run correctly
+# on linux/amd64.
 ENTRYPOINT [ \
     "aptos", \
     "node", \

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -2,12 +2,13 @@
 # multi-architecture builds to fail, so the hadolint rule for
 # version specification is disabled in this file.
 # hadolint global ignore=DL3008
-# cspell:word RUSTFLAGS
 # cspell:word hadolint
 # cspell:word libudev
 # cspell:word libclang
 # cspell:word libpq
 # cspell:word libdw
+# cspell:word localnet
+# cspell:word RUSTFLAGS
 
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG CLI_VERSION
@@ -53,3 +54,12 @@ ARG CLI_BINARY
 COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
 
 STOPSIGNAL SIGKILL
+
+ENTRYPOINT [ \
+    "aptos", \
+    "node", \
+    "run-localnet", \
+    "--with-indexer-api", \
+    "--bind-to", \
+    "0.0.0.0" \
+]

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -8,7 +8,7 @@
 # cspell:word libpq
 # cspell:word libdw
 # cspell:word localnet
-# cspell:word RUSTFLAGS
+# cspell:word rustflags
 
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG CLI_VERSION
@@ -23,46 +23,61 @@ ARG CLI_BINARY
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1 \
-    && apt-get update && apt-get install --no-install-recommends -y \
-        libudev-dev=252* \
-        build-essential=12* \
-        libclang-dev=1:14* \
-        libpq-dev=15* \
-        libssl-dev=3* \
-        libdw-dev=0.188* \
-        pkg-config=1.8* \
-        lld=1:14* \
-        curl=7* \
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
+    && apt-get update                                \
+    && apt-get install --no-install-recommends -y    \
+        libudev-dev=252*                             \
+        build-essential=12*                          \
+        libclang-dev=1:14*                           \
+        libpq-dev=15*                                \
+        libssl-dev=3*                                \
+        libdw-dev=0.188*                             \
+        pkg-config=1.8*                              \
+        lld=1:14*                                    \
+        curl=7*                                      \
     && rm -rf /var/lib/apt/lists/*
 
 # Resolve outdated lockfile from upstream tag, build the binary,
 # and strip it to reduce its size.
-RUN cargo update --manifest-path /aptos-core/Cargo.toml && \
-    RUSTFLAGS="--cfg tokio_unstable" cargo build \
-    --bin aptos \
-    --manifest-path /aptos-core/Cargo.toml \
-    --profile cli && \
-    strip -s $CLI_BINARY
+RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
+    && RUSTFLAGS="--cfg tokio_unstable" cargo build      \
+        --bin aptos                                      \
+        --manifest-path /aptos-core/Cargo.toml           \
+        --profile cli                                    \
+    && strip -s $CLI_BINARY
 
 FROM ubuntu:noble
+ARG CLI_BINARY
+
+RUN apt-get update                                 \
+    && apt-get install --no-install-recommends -y  \
+        curl=7*                                    \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-# Copy the executable to `/usr/local/bin` and add it to the PATH.
 ENV PATH=/usr/local/bin:$PATH
-ARG CLI_BINARY
 COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
 
 STOPSIGNAL SIGKILL
 
+# Set the default healthcheck to `curl` the default readiness endpoint.
+HEALTHCHECK                                   \
+    --interval=5s                             \
+    --timeout=5s                              \
+    --start-period=60s                        \
+    --retries=10                              \
+    CMD [ "curl", "http://localhost:8070/" ]
+
 # By default, run the localnet with the indexer API enabled and request to
 # bind to all interfaces. Without this flag, the node may not run correctly
 # on linux/amd64.
-ENTRYPOINT [ \
-    "aptos", \
-    "node", \
-    "run-localnet", \
-    "--with-indexer-api", \
-    "--bind-to", \
-    "0.0.0.0" \
+ENTRYPOINT [               \
+    "aptos",               \
+    "node",                \
+    "run-localnet",        \
+    "--with-indexer-api",  \
+    "--force-restart",     \
+    "--bind-to",           \
+    "0.0.0.0"              \
 ]


### PR DESCRIPTION
# Description

On linux machines, the node won't run unless `--bind-to 0.0.0.0` is passed to the CLI explicitly.

This PR adds this flag to the default entrypoint for the `econialabs/aptos-cli` image.

# Testing

Testing building and running the image on the `xbtmatt/aptos-cli` fork.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
