### PR TITLE
[ECO-2166] Fix curl version in `aptos-cli` `ubuntu:noble` image; fix `--bind-to` comment

### DIFF
--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -62,7 +62,7 @@ WORKDIR /app
 ENV PATH=/usr/local/bin:$PATH
 COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
 
-COPY sh/healthcheck.sh /app/sh/healthcheck.sh
+COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
 RUN chmod +x /app/sh/healthcheck.sh
 
 STOPSIGNAL SIGKILL

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -51,7 +51,7 @@ ARG CLI_BINARY
 
 RUN apt-get update                                 \
     && apt-get install --no-install-recommends -y  \
-        curl=7*                                    \
+        curl=8.5*                                  \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -69,9 +69,11 @@ HEALTHCHECK                                   \
     --retries=10                              \
     CMD [ "curl", "http://localhost:8070/" ]
 
-# By default, run the localnet with the indexer API enabled and request to
-# bind to all interfaces. Without this flag, the node may not run correctly
-# on linux/amd64.
+# Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
+# behavior of binding to 127.0.0.1 since `aptos` v2.3.2.
+# This is because the CLI is assumed to not be running inside a container, and
+# issues can arise on Windows when binding to 0.0.0.0.
+# See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
 ENTRYPOINT [               \
     "aptos",               \
     "node",                \

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -62,15 +62,17 @@ WORKDIR /app
 ENV PATH=/usr/local/bin:$PATH
 COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
 
+COPY sh/healthcheck.sh /app/sh/healthcheck.sh
+RUN chmod +x /app/sh/healthcheck.sh
+
 STOPSIGNAL SIGKILL
 
-# Set the default healthcheck to `curl` the default readiness endpoint.
 HEALTHCHECK                                   \
     --interval=5s                             \
     --timeout=5s                              \
     --start-period=60s                        \
     --retries=10                              \
-    CMD [ "curl", "http://localhost:8070/" ]
+    CMD [ "bash", "sh/healthcheck.sh" ]
 
 # Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
 # behavior of binding to 127.0.0.1 since `aptos` v2.3.2.

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -79,7 +79,6 @@ ENTRYPOINT [               \
     "node",                \
     "run-localnet",        \
     "--with-indexer-api",  \
-    "--force-restart",     \
     "--bind-to",           \
     "0.0.0.0"              \
 ]

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -51,7 +51,10 @@ ARG CLI_BINARY
 
 RUN apt-get update                                 \
     && apt-get install --no-install-recommends -y  \
+        ca-certificates=2024*                      \
         curl=8.5*                                  \
+        git=1:2.43*                                \
+        jq=1.7*                                    \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/src/aptos-cli/sh/healthcheck.sh
+++ b/src/aptos-cli/sh/healthcheck.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Note that the response from the readiness endpoint at http://localhost:8070
+# is a JSON object of the following structure:
+#
+# {
+#   "ready": [
+#       // Objects describing services that are ready.
+#   ],
+#   "not_ready": [
+#       // Objects describing services that are not ready.
+#   ]
+# }
+#
+# `curl` the readiness endpoint and check if the `not_ready` array is empty.
+# Pipe the output from `jq` to `grep` to check if the length is 0.
+
+curl -s http://localhost:8070/ | jq '.not_ready | length' | grep -q 0


### PR DESCRIPTION
# Description

Accidentally used the `curl` version for `rust:1-bookworm` instead of `ubuntu:noble`.

- [x] Fixed it by using the right version.
- [x] Fix the comment explanation for why we need to use `--bind-to`
- [x] Add a custom healthcheck with `jq`
- [x] Add default dependencies necessary to run most CLI commands (`ca-certificates`, `git`)

# Testing

Updating the tag and building the image in CI, tested it by pulling it locally for both architectures.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
