### PR TITLE
[ECO-2174] Fix healthcheck exit code logic

### DIFF
--- a/src/aptos-cli/sh/healthcheck.sh
+++ b/src/aptos-cli/sh/healthcheck.sh
@@ -15,4 +15,4 @@
 # `curl` the readiness endpoint and check if the `not_ready` array is empty.
 # Pipe the output from `jq` to `grep` to check if the length is 0.
 
-curl -s http://localhost:8070/ | jq '.not_ready | length' | grep -q 0
+curl -s http://localhost:8070/ | jq --exit-status '.not_ready | length == 0'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

@CRBl69 Caught this error post-merge, thankfully. The correction ensures that the healthcheck works as expected, with an exit code of `0` if the length of the `not_ready` JSON response from `localhost:8070` field is `0`, and `1` if the length is anything other than `0`.

# Testing

Note I'm using `fish`, but if you're using `bash` or something, you'd use `$?` instead of `$status`.

```shell
# Test an empty array
echo '{ "not_ready": [] }' | jq -e '.not_ready | length == 0'; echo $status
true # `jq` output
0 # exit status code from `jq`, which is what `Docker` uses to evaluate healthchecks

# Test a non-empty array
echo '{ "not_ready": [1, 2] }' | jq -e '.not_ready | length == 0'; echo $status
false
1

# Test another non-empty array
echo '{ "not_ready": [1] }' | jq -e '.not_ready | length == 0'; echo $status
false
1

# Test a non-empty array with a length that includes the value "0", i.e., "10"
echo '{ "not_ready": [1,2,3,4,5,6,7,8,9,10] }' | jq -e '.not_ready | length == 0'; echo $status
false
1

# Ensure `--exit-status` is the same thing as `-e`
echo '{ "not_ready": [] }' | jq --exit-status '.not_ready | length == 0'; echo $status
true
0
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
