### PR TITLE
[ECO-2678] Update Dockerfile to try to get the CLI to properly build

### DIFF
--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -67,7 +67,7 @@ jobs:
         file: 'src/aptos-cli/Dockerfile'
         push: true
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        platforms: 'linux/amd64'
         tags: '${{ steps.metadata.outputs.tags }}'
         build-args: |
           CLI_VERSION=${{ steps.metadata.outputs.version }}

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,25 +1,15 @@
-# cspell:word TOOLSDIRECTORY
 # cspell:word autoremove
+# cspell:word imagetools
+# cspell:word onlatest
 # cspell:word pipx
-# yamllint disable rule:empty-lines rule:key-ordering
-
+# cspell:word toolsdirectory
 ---
-name: 'Build the aptos-cli Docker image and push to Docker Hub'
-
-'on':
-  push:
-    tags:
-    - 'aptos-cli-v*'
-  workflow_dispatch:
-    inputs:
-      cli_version:
-        description: >-
-          Aptos CLI version to build, for example, 4.0.0
-        required: true
-        type: 'string'
 jobs:
-  build-push:
-    runs-on: 'ubuntu-latest'
+  build:
+    outputs:
+      amd64-tags: >-
+        ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
+    runs-on: '${{ matrix.runner }}'
     steps:
     - uses: 'actions/checkout@v4'
     - name: 'Remove unused packages to free up runner disk space'
@@ -42,34 +32,99 @@ jobs:
         sudo apt clean
         sudo apt autoremove -y
         df -h /
-      # yamllint enable rule:indentation
+    # yamllint enable rule:indentation
     - id: 'metadata'
       uses: 'docker/metadata-action@v5'
       with:
+        flavor: |
+          ${{ matrix.flavor }}
         images: 'econialabs/aptos-cli'
+        # yamllint disable rule:empty-lines
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}
 
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
-    - uses: 'docker/setup-qemu-action@v3'
+      # yamllint enable rule:empty-lines
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - uses: 'docker/build-push-action@v6'
+    - id: 'clean-version'
+      name: 'Strip -arm64 suffix from CLI version if needed'
+      run: |
+        VERSION="${{ steps.metadata.outputs.version }}"
+        if [[ "$VERSION" == *-arm64 ]]; then
+        VERSION="${VERSION%-arm64}"
+        fi
+        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
+    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
+      uses: 'docker/build-push-action@v6'
       with:
+        build-args: |
+          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
+        platforms: 'linux/${{ matrix.arch }}'
         push: true
-        labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: 'linux/arm64'
         tags: '${{ steps.metadata.outputs.tags }}'
-        build-args: |
-          CLI_VERSION=${{ steps.metadata.outputs.version }}
-    timeout-minutes: 360
+    strategy:
+      matrix:
+        include:
+        - arch: 'amd64'
+          flavor: null
+          runner: 'ubuntu-latest'
+        - arch: 'arm64'
+          flavor: |
+            suffix=-arm64,onlatest=true
+          runner: 'ubuntu-24.04-arm'
+  update-manifest:
+    needs: 'build'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'docker/login-action@v3'
+      with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - id: 'base-url'
+      # Use `tr` to remove whitespace from the constructed URL before saving
+      # the output for later use.
+      run: |
+        DOCKER_ORG="econialabs"
+        REPO_NAME="aptos-cli"
+        BASE_URL="https://hub.docker.com/v2/repositories/\
+        ${DOCKER_ORG}/\
+        ${REPO_NAME}/\
+        tags"
+        BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
+        echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
+    - name: 'Append ARM images to AMD manifest, remove old ARM images'
+      # Loop over all the AMD64 tags and append the ARM64 tags to the manifest,
+      # then delete the old ARM64 tags from Docker Hub.
+      run: |
+        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
+        if [ ! -z "$tag" ]; then
+        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+        VERSION=$(echo "$tag" | cut -d':' -f2)
+        curl -X DELETE \
+        -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
+        "${{ steps.base-url.outputs.url }}/${VERSION}-arm64/"
+        fi
+        done
+name: 'Build the aptos-cli Docker image and push to Docker Hub'
+'on':
+  push:
+    tags:
+    - 'aptos-cli-v*'
+  workflow_dispatch:
+    inputs:
+      cli_version:
+        description: >-
+          Aptos CLI version to build, for example, 4.0.0
+        required: true
+        type: 'string'
 ...

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -67,7 +67,7 @@ jobs:
         file: 'src/aptos-cli/Dockerfile'
         push: true
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: 'linux/amd64'
+        platforms: 'linux/arm64'
         tags: '${{ steps.metadata.outputs.tags }}'
         build-args: |
           CLI_VERSION=${{ steps.metadata.outputs.version }}

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -16,16 +16,6 @@ repos:
 -
   hooks:
   -
-    args:
-    - '--config-file'
-    - 'cfg/yamllint-config.yaml'
-    - '--strict'
-    id: 'yamllint'
-  repo: 'https://github.com/adrienverge/yamllint'
-  rev: 'v1.34.0'
--
-  hooks:
-  -
     entry: './src/sh/ensure-shebang.sh'
     id: 'ensure-shebang'
     language: 'script'

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -43,7 +43,6 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
 RUN cargo build                                 \
         --bin aptos                             \
         --manifest-path /aptos-core/Cargo.toml  \
-        --profile cli                           \
     && strip -s $CLI_BINARY
 
 FROM ubuntu:noble

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -21,7 +21,9 @@ ARG GIT_REPO
 ARG GIT_TAG
 ARG CLI_BINARY
 
+# Set environment variables to improve build compatibility.
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV RUSTFLAGS="-C linker=lld --cfg tokio_unstable"
 
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
     && apt-get update                                \
@@ -40,7 +42,7 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
 # Resolve outdated lockfile from upstream tag, build the binary,
 # and strip it to reduce its size.
 RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
-    && RUSTFLAGS="--cfg tokio_unstable" cargo build      \
+    && cargo build                                       \
         --bin aptos                                      \
         --manifest-path /aptos-core/Cargo.toml           \
         --profile cli                                    \

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -45,6 +45,7 @@ RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
     && cargo build                                       \
         --bin aptos                                      \
         --manifest-path /aptos-core/Cargo.toml           \
+        --profile cli                                    \
     && strip -s $CLI_BINARY
 
 FROM ubuntu:noble

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -23,7 +23,7 @@ ARG CLI_BINARY
 
 # Set environment variables to improve build compatibility.
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-ENV RUSTFLAGS="-C linker=lld --cfg tokio_unstable"
+ENV RUSTFLAGS="--cfg tokio_unstable"
 
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
     && apt-get update                                \
@@ -39,13 +39,11 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
         curl=7*                                      \
     && rm -rf /var/lib/apt/lists/*
 
-# Resolve outdated lockfile from upstream tag, build the binary,
-# and strip it to reduce its size.
-RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
-    && cargo build                                       \
-        --bin aptos                                      \
-        --manifest-path /aptos-core/Cargo.toml           \
-        --profile cli                                    \
+# Build the binary and strip it to reduce its size.
+RUN cargo build                                 \
+        --bin aptos                             \
+        --manifest-path /aptos-core/Cargo.toml  \
+        --profile cli                           \
     && strip -s $CLI_BINARY
 
 FROM ubuntu:noble

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -39,10 +39,12 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
         curl=7*                                      \
     && rm -rf /var/lib/apt/lists/*
 
-# Build the binary and strip it to reduce its size.
-RUN cargo build                                 \
-        --bin aptos                             \
-        --manifest-path /aptos-core/Cargo.toml  \
+# Resolve outdated lockfile from upstream tag, build the binary,
+# and strip it to reduce its size.
+RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
+    && cargo build                                       \
+        --bin aptos                                      \
+        --manifest-path /aptos-core/Cargo.toml           \
     && strip -s $CLI_BINARY
 
 FROM ubuntu:noble

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -1,8 +1,3 @@
-# Specifying package versions in `apt-get` commands can cause
-# multi-architecture builds to fail, so the hadolint rule for
-# version specification is disabled in this file.
-# hadolint global ignore=DL3008
-# cspell:word hadolint
 # cspell:word libudev
 # cspell:word libclang
 # cspell:word libpq
@@ -10,70 +5,63 @@
 # cspell:word localnet
 # cspell:word rustflags
 
-ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
+ARG BUILDER_VERSION=1.1.0
+# Default to compile using as many logical CPUs as possible.
+ARG CARGO_BUILD_JOBS=-1
+ARG CLI_BINARY=aptos-core/target/cli/aptos
 ARG CLI_VERSION
+ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
-ARG CLI_BINARY=/aptos-core/target/cli/aptos
 
-FROM rust:1-bookworm AS aptos-cli
-
+# Install buildtime dependencies.
+FROM econialabs/rust-builder:$BUILDER_VERSION AS builder
+ARG CARGO_BUILD_JOBS
+ARG CLI_BINARY
 ARG GIT_REPO
 ARG GIT_TAG
-ARG CLI_BINARY
-
-# Set environment variables to improve build compatibility.
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-ENV RUSTFLAGS="--cfg tokio_unstable"
-
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
-    && apt-get update                                \
-    && apt-get install --no-install-recommends -y    \
-        libudev-dev=252*                             \
-        build-essential=12*                          \
-        libclang-dev=1:14*                           \
-        libpq-dev=15*                                \
-        libssl-dev=3*                                \
-        libdw-dev=0.188*                             \
-        pkg-config=1.8*                              \
-        lld=1:14*                                    \
-        curl=7*                                      \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libudev-dev=252* \
+        build-essential=12* \
+        libclang-dev=1:14* \
+        libpq-dev=15* \
+        libssl-dev=3* \
+        libdw-dev=0.188* \
+        pkg-config=1.8* \
+        lld=1:14* \
+        curl=7* \
     && rm -rf /var/lib/apt/lists/*
 
-# Resolve outdated lockfile from upstream tag, build the binary,
-# and strip it to reduce its size.
-RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
-    && cargo build                                       \
-        --bin aptos                                      \
-        --manifest-path /aptos-core/Cargo.toml           \
-        --profile cli                                    \
-    && strip -s $CLI_BINARY
+# Clone aptos-core, update a known offending dependency, build the CLI binary
+# using specified number of parallel jobs, then strip it.
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+WORKDIR /aptos-core
+RUN cargo update --package time \
+    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
+WORKDIR /
+RUN strip -s "$CLI_BINARY"
 
-FROM ubuntu:noble
+# Install runtime dependencies, copy over binary.
+FROM debian:bookworm-slim AS runtime
 ARG CLI_BINARY
-
-RUN apt-get update                                 \
-    && apt-get install --no-install-recommends -y  \
-        ca-certificates=2024*                      \
-        curl=8.5*                                  \
-        git=1:2.43*                                \
-        jq=1.7*                                    \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates=2023* \
+        curl=7* \
+        git=1:2.39* \
+        jq=1.6* \
     && rm -rf /var/lib/apt/lists/*
+COPY --from=builder $CLI_BINARY /usr/local/bin
 
-WORKDIR /app
-
-ENV PATH=/usr/local/bin:$PATH
-COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
-
+# Copy over healthcheck script, make it executable so it can be run.
+WORKDIR /
 COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
-RUN chmod +x /app/sh/healthcheck.sh
-
-STOPSIGNAL SIGKILL
-
-HEALTHCHECK                                   \
-    --interval=5s                             \
-    --timeout=5s                              \
-    --start-period=60s                        \
-    --retries=10                              \
+RUN chmod +x sh/healthcheck.sh
+HEALTHCHECK \
+    --interval=5s \
+    --timeout=5s \
+    --start-period=60s \
+    --retries=10 \
     CMD [ "bash", "sh/healthcheck.sh" ]
 
 # Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
@@ -81,11 +69,13 @@ HEALTHCHECK                                   \
 # This is because the CLI is assumed to not be running inside a container, and
 # issues can arise on Windows when binding to 0.0.0.0.
 # See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
-ENTRYPOINT [               \
-    "aptos",               \
-    "node",                \
-    "run-localnet",        \
-    "--with-indexer-api",  \
-    "--bind-to",           \
-    "0.0.0.0"              \
+ENTRYPOINT [ \
+    "aptos", \
+    "node", \
+    "run-localnet", \
+    "--with-indexer-api", \
+    "--bind-to", \
+    "0.0.0.0" \
 ]
+
+STOPSIGNAL SIGKILL

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -10,36 +10,36 @@ The Aptos CLI is available for various platforms and architectures as a
 standalone executable; however, there isn't a ready-to-use Docker image for the
 `aarch64` processor architecture (labeled as `linux/arm64/v8` in Docker).
 
-This architecture is particularly significant, as it's used in the arm-based
+This architecture is particularly significant, as it's used in the ARM-based
 Apple silicon found in newer Macbooks.
 
 The image built from this Dockerfile serves to address this gap and provide a
 solution for users working with these systems.
 
 It builds an image of the `aptos` CLI for `linux/arm64` and `linux/amd64`, with
-the CLI version corresponding directly Docker image tag:
+the CLI version corresponding directly to the Docker image tag:
 
 ```Dockerfile
-# Uses the aptos CLI, version 4.0.0
-FROM econialabs/aptos-cli:4.0.0
+# Uses the aptos CLI, version 6.0.2
+FROM econialabs/aptos-cli:6.0.2
 
 RUN aptos --version
-# > aptos 4.0.0
+# > aptos 6.0.2
 ```
 
-## Building the image and pushing it to the `econialabs` Docker hub
+## Building the image and pushing it to the `econialabs` Docker Hub registry
 
 To build a Docker image with a specific version of the Aptos CLI, simply push
 the corresponding version tag to GitHub to trigger the GitHub workflow that
 builds the image in CI:
 
 ```shell
-git tag aptos-cli-v4.0.0
+git tag aptos-cli-vX.Y.Z
 ```
 
 This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos`
 CLI Docker image and subsequently push it to the `econialabs` Dockerhub
-repository as `econialabs/aptos-cli:4.0.0`.
+repository as `econialabs/aptos-cli:X.Y.Z`.
 
 ## Triggering the workflow manually
 
@@ -48,13 +48,13 @@ The action is also set to trigger manually on `workflow_dispatch`.
 You will be prompted to input the version, which will work with both of the
 following formats:
 
-`cli_version: v4.0.0`
+`cli_version: vX.Y.Z`
 
 or
 
-`cli_version: 4.0.0`
+`cli_version: X.Y.Z`
 
-Since the Dockerfile strips the `v` when parsing the `ARG CLI_VERSION` value.
+Since the action strips the `v` when parsing the `ARG CLI_VERSION` value.
 
 ## Multi-architecture support
 
@@ -74,7 +74,7 @@ A simple `bash` script for this process might be something like:
 git_root=$(git rev-parse --show-toplevel)
 
 username=YOUR_DOCKERHUB_USERNAME
-version=v4.0.0
+version=v6.0.2
 
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
@@ -84,3 +84,18 @@ docker buildx build \
   --push \
   .
 ```
+
+## Resource consumption
+
+Since the `aptos` binary has so many dependencies, compilation may fail due to
+resource exhaustion unless adequate measures are taken.
+
+If you are building locally then you should be able to prevent failure by simply
+increasing your [Docker Desktop resources], in particular `CPU limit` and
+`Memory limit`.
+
+Alternatively, you can pass [`CARGO_BUILD_JOBS`] as a `build-arg` to limit the
+number of parallel compilation processes.
+
+[docker desktop resources]: https://docs.docker.com/desktop/settings-and-maintenance/settings/#advanced
+[`cargo_build_jobs`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables


### PR DESCRIPTION
# Description

This is necessary to build the new arena package in the deployer image, since the Move contract uses the new `+=` syntax.

# Testing

If it builds, it works.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
