### PR TITLE
[ECO-2733] Bump `rust-builder` versions

### DIFF
--- a/src/rust-builder/Dockerfile
+++ b/src/rust-builder/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.79.0-slim-bookworm
-RUN cargo install cargo-chef@0.1.67
+FROM rust:1.84.1-slim-bookworm
+RUN cargo install cargo-chef@0.1.71
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git=1:2.39.2-1.1 \
+    git=1:2.39.5* \
     && rm -rf /var/lib/apt/lists/*
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true

--- a/src/rust-builder/template.Dockerfile
+++ b/src/rust-builder/template.Dockerfile
@@ -1,6 +1,6 @@
 # Chainguard image digest (SHA-256), Rust builder version.
-ARG DIGEST=5567380ef73d947c834960aa127784eef821c69596366dd48caf77736e854bc2
-ARG BUILDER_VERSION=1.0.0
+ARG DIGEST=c907cf5576de12bb54ac2580a91d0287de55f56bce4ddd66a0edf5ebaba9feed
+ARG BUILDER_VERSION=1.1.0
 
 FROM econialabs/rust-builder:$BUILDER_VERSION AS base
 WORKDIR /app


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Bump assorted versions for Rust builder.

# Testing

1. From inside `src/rust-builder`, run `docker build . -t rust-builder-v1.1.0`.
1. Then follow `src/rust-builder` README.
