### PR TITLE
[ECO-2737] CLI Dockerfile suggestions

### DIFF
--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,7 +7,8 @@
 jobs:
   build:
     outputs:
-      tags: ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
+      tags: |
+        ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
 #    - uses: 'actions/checkout@v4'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,7 +7,7 @@
 jobs:
   build:
     outputs:
-      tags: |
+      tags: >
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -34,22 +34,28 @@ jobs:
       uses: 'docker/metadata-action@v5'
       with:
         images: 'econialabs/aptos-cli'
+        # yamllint disable rule:empty-lines
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}\n
+          enable=${{ github.event_name == 'push' }}
+
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
+      # yamllint enable rule:empty-lines
     - id: 'arm64-metadata'
       uses: 'docker/metadata-action@v5'
       with:
         flavor: |
           suffix=-arm64,onlatest=true
         images: 'econialabs/aptos-cli'
+        # yamllint disable rule:empty-lines
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}\n
+          enable=${{ github.event_name == 'push' }}
+
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
+      # yamllint enable rule:empty-lines
     - uses: 'docker/setup-qemu-action@v3'
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,6 +7,7 @@
 jobs:
   amd-test:
     runs-on: 'ubuntu-latest'
+    steps:
     - run: 'echo "Hello, AMD!"'
   arm-test:
     runs-on: 'ubuntu-24.04-arm'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -65,7 +65,6 @@ jobs:
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
-        labels: '${{ steps.metadata.outputs.labels }}'
         platforms: 'linux/amd64'
         push: true
         tags: '${{ steps.metadata.outputs.tags }}'
@@ -75,12 +74,11 @@ jobs:
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CLI_VERSION=${{ steps.metadata.outputs.version }}
+          CLI_VERSION=${{ steps.arm-metadata.outputs.version }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
-        labels: '${{ steps.arm64-metadata.outputs.labels }}'
         platforms: 'linux/arm64'
         push: true
         tags: '${{ steps.arm64-metadata.outputs.tags }}'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -90,14 +90,27 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Append ARM images to AMD manifest, remove old ARM images'
+    - id: 'base-url'
       run: |
-        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
-        if [ ! -z "$tag" ]; then
-        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
-        docker rmi "docker.io/$tag-arm64"
-        fi
-        done
+        DOCKER_ORG="econialabs"
+        REPO_NAME="aptos-cli"
+        BASE_URL="https://hub.docker.com/v2/repositories/\
+          ${DOCKER_ORG}/\
+          ${REPO_NAME}/\
+          tags"
+        BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
+        echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
+    - run: "echo ${{ steps.base-url.outputs.url }}"
+#     - name: 'Append ARM images to AMD manifest, remove old ARM images'
+#       run: |
+#         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
+#         if [ ! -z "$tag" ]; then
+#         docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+#         curl -X DELETE \
+#         -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
+#         "${{ steps.base-url.outputs.url }}/$tag-arm64/"
+#         fi
+#         done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,22 +1,9 @@
-# cspell:word TOOLSDIRECTORY
 # cspell:word autoremove
+# cspell:word imagetools
+# cspell:word onlatest
 # cspell:word pipx
-# yamllint disable rule:empty-lines rule:key-ordering
-
+# cspell:word toolsdirectory
 ---
-name: 'Build the aptos-cli Docker image and push to Docker Hub'
-
-'on':
-  push:
-    tags:
-    - 'aptos-cli-v*'
-  workflow_dispatch:
-    inputs:
-      cli_version:
-        description: >-
-          Aptos CLI version to build, for example, 4.0.0
-        required: true
-        type: 'string'
 jobs:
   build-push:
     runs-on: 'ubuntu-latest'
@@ -50,7 +37,17 @@ jobs:
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}
-
+          type=raw,value=${{ github.event.inputs.cli_version }},
+          enable=${{ github.event_name == 'workflow_dispatch' }}
+    - id: 'arm64-metadata'
+      uses: 'docker/metadata-action@v5'
+      with:
+        flavor: |
+          suffix=-arm64,onlatest=true
+        images: 'econialabs/aptos-cli'
+        tags: >
+          type=match,pattern=aptos-cli-v(.*),group=1,
+          enable=${{ github.event_name == 'push' }}
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
     - uses: 'docker/setup-qemu-action@v3'
@@ -59,17 +56,52 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - name: 'Push AMD image to Docker Hub'
     - uses: 'docker/build-push-action@v6'
       with:
+        build-args: |
+          CLI_VERSION=${{ steps.metadata.outputs.version }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
-        push: true
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        platforms: 'linux/amd64'
+        push: true
         tags: '${{ steps.metadata.outputs.tags }}'
+    - name: 'Clear Docker cache to free up space for ARM build'
+      run: 'docker system prune -af'
+    - name: 'Push ARM image to Docker Hub'
+      uses: 'docker/build-push-action@v6'
+      with:
         build-args: |
           CLI_VERSION=${{ steps.metadata.outputs.version }}
+        cache-from: 'type=gha'
+        cache-to: 'type=gha,mode=max'
+        context: '.'
+        file: 'src/aptos-cli/Dockerfile'
+        labels: '${{ steps.metadata.outputs.labels }}'
+        platforms: 'linux/arm64'
+        push: true
+        tags: '${{ steps.arm64-metadata.outputs.tags }}'
+    - name: 'Append ARM images to AMD manifest'
+      run: |
+        echo "${{ steps.metadata.outputs.tags }}" | while read -r tag; do
+        if [ ! -z "$tag" ]; then
+        docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
+        fi
+        done
     timeout-minutes: 360
+name: 'Build the aptos-cli Docker image and push to Docker Hub'
+'on':
+  push:
+    tags:
+    - 'aptos-cli-v*'
+  workflow_dispatch:
+    inputs:
+      cli_version:
+        description: >-
+          Aptos CLI version to build, for example, 4.0.0
+        required: true
+        type: 'string'
 ...

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,7 +7,7 @@
 jobs:
   build:
     outputs:
-      amd64-tags: >
+      amd64-tags: >-
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -96,8 +96,8 @@ jobs:
       run: |
         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then
-        docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
-        docker rmi "docker.io/${tag}-arm64"
+        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+        docker rmi "docker.io/$tag-arm64"
         fi
         done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -92,11 +92,12 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Append ARM images to AMD manifest'
+    - name: 'Append ARM images to AMD manifest, remove old ARM images'
       run: |
         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then
         docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
+        docker rmi "docker.io/${tag}-arm64"
         fi
         done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -74,8 +74,8 @@ jobs:
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CLI_VERSION=${{ steps.arm64-metadata.outputs.version }}
           CARGO_BUILD_JOBS=3
+          CLI_VERSION=${{ steps.arm64-metadata.outputs.version }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -11,27 +11,27 @@ jobs:
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
-#    - uses: 'actions/checkout@v4'
-#    - name: 'Remove unused packages to free up runner disk space'
-#      # yamllint disable rule:indentation
-#      run: |
-#        sudo rm -rf \
-#          "$AGENT_TOOLSDIRECTORY" \
-#          /opt/google/chrome \
-#          /opt/microsoft/msedge \
-#          /opt/microsoft/powershell \
-#          /opt/pipx \
-#          /usr/lib/mono \
-#          /usr/local/julia* \
-#          /usr/local/lib/android \
-#          /usr/local/lib/node_modules \
-#          /usr/local/share/chromium \
-#          /usr/local/share/powershell \
-#          /usr/share/dotnet \
-#          /usr/share/swift
-#        sudo apt clean
-#        sudo apt autoremove -y
-#        df -h /
+    - uses: 'actions/checkout@v4'
+    - name: 'Remove unused packages to free up runner disk space'
+      # yamllint disable rule:indentation
+      run: |
+        sudo rm -rf \
+          "$AGENT_TOOLSDIRECTORY" \
+          /opt/google/chrome \
+          /opt/microsoft/msedge \
+          /opt/microsoft/powershell \
+          /opt/pipx \
+          /usr/lib/mono \
+          /usr/local/julia* \
+          /usr/local/lib/android \
+          /usr/local/lib/node_modules \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift
+        sudo apt clean
+        sudo apt autoremove -y
+        df -h /
     # yamllint enable rule:indentation
     - id: 'metadata'
       uses: 'docker/metadata-action@v5'
@@ -47,31 +47,31 @@ jobs:
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
       # yamllint enable rule:empty-lines
-#    - uses: 'docker/setup-buildx-action@v3'
-#    - uses: 'docker/login-action@v3'
-#      with:
-#        password: '${{ secrets.DOCKERHUB_TOKEN }}'
-#        username: '${{ secrets.DOCKERHUB_USERNAME }}'
-#    - id: 'clean-version'
-#      name: 'Strip -arm64 suffix from CLI version if needed'
-#      run: |
-#        VERSION="${{ steps.metadata.outputs.version }}"
-#        if [[ "$VERSION" == *-arm64 ]]; then
-#        VERSION="${VERSION%-arm64}"
-#        fi
-#        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
-#    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
-#      uses: 'docker/build-push-action@v6'
-#      with:
-#        build-args: |
-#          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
-#        cache-from: 'type=gha'
-#        cache-to: 'type=gha,mode=max'
-#        context: '.'
-#        file: 'src/aptos-cli/Dockerfile'
-#        platforms: 'linux/${{ matrix.arch }}'
-#        push: true
-#        tags: '${{ steps.metadata.outputs.tags }}'
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
+      with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - id: 'clean-version'
+      name: 'Strip -arm64 suffix from CLI version if needed'
+      run: |
+        VERSION="${{ steps.metadata.outputs.version }}"
+        if [[ "$VERSION" == *-arm64 ]]; then
+        VERSION="${VERSION%-arm64}"
+        fi
+        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
+    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
+      uses: 'docker/build-push-action@v6'
+      with:
+        build-args: |
+          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
+        cache-from: 'type=gha'
+        cache-to: 'type=gha,mode=max'
+        context: '.'
+        file: 'src/aptos-cli/Dockerfile'
+        platforms: 'linux/${{ matrix.arch }}'
+        push: true
+        tags: '${{ steps.metadata.outputs.tags }}'
     strategy:
       matrix:
         include:
@@ -103,6 +103,8 @@ jobs:
         BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
         echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
     - name: 'Append ARM images to AMD manifest, remove old ARM images'
+      # Loop over all the AMD64 tags and append the ARM64 tags to the manifest,
+      # then delete the old ARM64 tags from Docker Hub.
       run: |
         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -107,9 +107,10 @@ jobs:
         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then
         docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+        VERSION=$(echo "$tag" | cut -d':' -f2)
         curl -X DELETE \
         -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
-        "${{ steps.base-url.outputs.url }}/$tag-arm64/"
+        "${{ steps.base-url.outputs.url }}/${VERSION}-arm64/"
         fi
         done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -11,27 +11,27 @@ jobs:
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
-    - uses: 'actions/checkout@v4'
-    - name: 'Remove unused packages to free up runner disk space'
-      # yamllint disable rule:indentation
-      run: |
-        sudo rm -rf \
-          "$AGENT_TOOLSDIRECTORY" \
-          /opt/google/chrome \
-          /opt/microsoft/msedge \
-          /opt/microsoft/powershell \
-          /opt/pipx \
-          /usr/lib/mono \
-          /usr/local/julia* \
-          /usr/local/lib/android \
-          /usr/local/lib/node_modules \
-          /usr/local/share/chromium \
-          /usr/local/share/powershell \
-          /usr/share/dotnet \
-          /usr/share/swift
-        sudo apt clean
-        sudo apt autoremove -y
-        df -h /
+#    - uses: 'actions/checkout@v4'
+#    - name: 'Remove unused packages to free up runner disk space'
+#      # yamllint disable rule:indentation
+#      run: |
+#        sudo rm -rf \
+#          "$AGENT_TOOLSDIRECTORY" \
+#          /opt/google/chrome \
+#          /opt/microsoft/msedge \
+#          /opt/microsoft/powershell \
+#          /opt/pipx \
+#          /usr/lib/mono \
+#          /usr/local/julia* \
+#          /usr/local/lib/android \
+#          /usr/local/lib/node_modules \
+#          /usr/local/share/chromium \
+#          /usr/local/share/powershell \
+#          /usr/share/dotnet \
+#          /usr/share/swift
+#        sudo apt clean
+#        sudo apt autoremove -y
+#        df -h /
     # yamllint enable rule:indentation
     - id: 'metadata'
       uses: 'docker/metadata-action@v5'
@@ -47,31 +47,31 @@ jobs:
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
       # yamllint enable rule:empty-lines
-    - uses: 'docker/setup-buildx-action@v3'
-    - uses: 'docker/login-action@v3'
-      with:
-        password: '${{ secrets.DOCKERHUB_TOKEN }}'
-        username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - id: 'clean-version'
-      name: 'Strip -arm64 suffix from CLI version if needed'
-      run: |
-        VERSION="${{ steps.metadata.outputs.version }}"
-        if [[ "$VERSION" == *-arm64 ]]; then
-        VERSION="${VERSION%-arm64}"
-        fi
-        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
-    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
-      uses: 'docker/build-push-action@v6'
-      with:
-        build-args: |
-          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
-        cache-from: 'type=gha'
-        cache-to: 'type=gha,mode=max'
-        context: '.'
-        file: 'src/aptos-cli/Dockerfile'
-        platforms: 'linux/${{ matrix.arch }}'
-        push: true
-        tags: '${{ steps.metadata.outputs.tags }}'
+#    - uses: 'docker/setup-buildx-action@v3'
+#    - uses: 'docker/login-action@v3'
+#      with:
+#        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+#        username: '${{ secrets.DOCKERHUB_USERNAME }}'
+#    - id: 'clean-version'
+#      name: 'Strip -arm64 suffix from CLI version if needed'
+#      run: |
+#        VERSION="${{ steps.metadata.outputs.version }}"
+#        if [[ "$VERSION" == *-arm64 ]]; then
+#        VERSION="${VERSION%-arm64}"
+#        fi
+#        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
+#    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
+#      uses: 'docker/build-push-action@v6'
+#      with:
+#        build-args: |
+#          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
+#        cache-from: 'type=gha'
+#        cache-to: 'type=gha,mode=max'
+#        context: '.'
+#        file: 'src/aptos-cli/Dockerfile'
+#        platforms: 'linux/${{ matrix.arch }}'
+#        push: true
+#        tags: '${{ steps.metadata.outputs.tags }}'
     strategy:
       matrix:
         include:
@@ -86,19 +86,19 @@ jobs:
     needs: 'build'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Append ARM images to AMD manifest, remove old ARM images'
-      run: |
-        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
-        if [ ! -z "$tag" ]; then
-        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
-        docker rmi "docker.io/$tag-arm64"
-        fi
-        done
+    - rune: echo "${{ needs.build.outputs.amd64-tags }}"
+#     - name: 'Append ARM images to AMD manifest, remove old ARM images'
+#       run: |
+#         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
+#         if [ ! -z "$tag" ]; then
+#         docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+#         docker rmi "docker.io/$tag-arm64"
+#         fi
+#         done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -5,7 +5,7 @@
 # cspell:word toolsdirectory
 ---
 jobs:
-  build-push:
+  build-amd64:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'actions/checkout@v4'
@@ -42,21 +42,6 @@ jobs:
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
       # yamllint enable rule:empty-lines
-    - id: 'arm64-metadata'
-      uses: 'docker/metadata-action@v5'
-      with:
-        flavor: |
-          suffix=-arm64,onlatest=true
-        images: 'econialabs/aptos-cli'
-        # yamllint disable rule:empty-lines
-        tags: >
-          type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
-          type=raw,value=${{ github.event.inputs.cli_version }},
-          enable=${{ github.event_name == 'workflow_dispatch' }}
-      # yamllint enable rule:empty-lines
-    - uses: 'docker/setup-qemu-action@v3'
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
       with:
@@ -74,29 +59,80 @@ jobs:
         platforms: 'linux/amd64'
         push: true
         tags: '${{ steps.metadata.outputs.tags }}'
-    - name: 'Clear Docker cache to free up space for ARM build'
-      run: 'docker system prune -af'
+  build-arm64:
+    runs-on: 'ubuntu-24.04-arm'
+    steps:
+    - uses: 'actions/checkout@v4'
+    - name: 'Remove unused packages to free up runner disk space'
+      # yamllint disable rule:indentation
+      run: |
+        sudo rm -rf \
+          "$AGENT_TOOLSDIRECTORY" \
+          /opt/google/chrome \
+          /opt/microsoft/msedge \
+          /opt/microsoft/powershell \
+          /opt/pipx \
+          /usr/lib/mono \
+          /usr/local/julia* \
+          /usr/local/lib/android \
+          /usr/local/lib/node_modules \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift
+        sudo apt clean
+        sudo apt autoremove -y
+        df -h /
+      # yamllint enable rule:indentation
+    - id: 'metadata'
+      uses: 'docker/metadata-action@v5'
+      with:
+        flavor: |
+          suffix=-arm64,onlatest=true
+        images: 'econialabs/aptos-cli'
+        # yamllint disable rule:empty-lines
+        tags: >
+          type=match,pattern=aptos-cli-v(.*),group=1,
+          enable=${{ github.event_name == 'push' }}
+
+          type=raw,value=${{ github.event.inputs.cli_version }},
+          enable=${{ github.event_name == 'workflow_dispatch' }}
+      # yamllint enable rule:empty-lines
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
+      with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - name: 'Push ARM image to Docker Hub'
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CARGO_BUILD_JOBS=3
-          CLI_VERSION=${{ steps.arm64-metadata.outputs.version }}
+          CLI_VERSION=${{ steps.metadata.outputs.version }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
         platforms: 'linux/arm64'
         push: true
-        tags: '${{ steps.arm64-metadata.outputs.tags }}'
+        tags: '${{ steps.metadata.outputs.tags }}'
+  update-manifest:
+    needs:
+    - 'build-amd64'
+    - 'build-arm64'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
+      with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - name: 'Append ARM images to AMD manifest'
       run: |
-        echo "${{ steps.metadata.outputs.tags }}" | while read -r tag; do
+        echo "${{ needs.build-amd64.outputs.tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then
         docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
         fi
         done
-    timeout-minutes: 360
 name: 'Build the aptos-cli Docker image and push to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -90,15 +90,14 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - run: echo "${{ needs.build.outputs.amd64-tags }}"
-#     - name: 'Append ARM images to AMD manifest, remove old ARM images'
-#       run: |
-#         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
-#         if [ ! -z "$tag" ]; then
-#         docker buildx imagetools create --append -t "$tag" "$tag-arm64"
-#         docker rmi "docker.io/$tag-arm64"
-#         fi
-#         done
+    - name: 'Append ARM images to AMD manifest, remove old ARM images'
+      run: |
+        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
+        if [ ! -z "$tag" ]; then
+        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+        docker rmi "docker.io/$tag-arm64"
+        fi
+        done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -34,10 +34,9 @@ jobs:
       uses: 'docker/metadata-action@v5'
       with:
         images: 'econialabs/aptos-cli'
-        tags: >
+        tags: >-
           type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
+          enable=${{ github.event_name == 'push' }}\n
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
     - id: 'arm64-metadata'
@@ -46,10 +45,9 @@ jobs:
         flavor: |
           suffix=-arm64,onlatest=true
         images: 'econialabs/aptos-cli'
-        tags: >
+        tags: >-
           type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
+          enable=${{ github.event_name == 'push' }}\n
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
     - uses: 'docker/setup-qemu-action@v3'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: 'docker/metadata-action@v5'
       with:
         images: 'econialabs/aptos-cli'
-        tags: >-
+        tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}\n
           type=raw,value=${{ github.event.inputs.cli_version }},
@@ -45,7 +45,7 @@ jobs:
         flavor: |
           suffix=-arm64,onlatest=true
         images: 'econialabs/aptos-cli'
-        tags: >-
+        tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}\n
           type=raw,value=${{ github.event.inputs.cli_version }},

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -57,7 +57,7 @@ jobs:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - name: 'Push AMD image to Docker Hub'
-    - uses: 'docker/build-push-action@v6'
+      uses: 'docker/build-push-action@v6'
       with:
         build-args: |
           CLI_VERSION=${{ steps.metadata.outputs.version }}

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,7 +7,7 @@
 jobs:
   build:
     outputs:
-      tags: >
+      amd64-tags: >
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
@@ -90,7 +90,7 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - run: echo "${{ needs.build.outputs.tags }}"
+    - run: echo "${{ needs.build.outputs.amd64-tags }}"
 #     - name: 'Append ARM images to AMD manifest, remove old ARM images'
 #       run: |
 #         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -53,13 +53,18 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - name: 'Strip -arm64 suffix from CLI version if needed'
+      run: |
+        VERSION="${{ steps.metadata.outputs.version }}"
+        if [[ "$VERSION" == *-arm64 ]]; then
+        VERSION="${VERSION%-arm64}"
+        fi
+        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
     - name: 'Push ${{ matrix.arch }} image to Docker Hub'
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CLI_VERSION=${{
-          replace(steps.metadata.outputs.version, '-arm64', '')
-          }}
+          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -5,20 +5,11 @@
 # cspell:word toolsdirectory
 ---
 jobs:
-  amd-test:
-    runs-on: 'ubuntu-latest'
-    steps:
-    - run: 'echo "Hello, AMD!"'
-  arm-test:
-    runs-on: 'ubuntu-24.04-arm'
-    steps:
-    - run: 'echo "Hello, ARM!"'
   build:
     outputs:
       amd64-tags: |
         ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
-    runs-on: |
-      ${{ matrix.runner }}
+    runs-on: '${{ matrix.runner }}'
     steps:
     - uses: 'actions/checkout@v4'
     - name: 'Remove unused packages to free up runner disk space'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -74,7 +74,8 @@ jobs:
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CLI_VERSION=${{ steps.arm-metadata.outputs.version }}
+          CLI_VERSION=${{ steps.arm64-metadata.outputs.version }}
+          CARGO_BUILD_JOBS=3
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -97,9 +97,9 @@ jobs:
         DOCKER_ORG="econialabs"
         REPO_NAME="aptos-cli"
         BASE_URL="https://hub.docker.com/v2/repositories/\
-          ${DOCKER_ORG}/\
-          ${REPO_NAME}/\
-          tags"
+        ${DOCKER_ORG}/\
+        ${REPO_NAME}/\
+        tags"
         BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
         echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
     - name: 'Append ARM images to AMD manifest, remove old ARM images'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -91,6 +91,8 @@ jobs:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - id: 'base-url'
+      # Use `tr` to remove whitespace from the constructed URL before saving
+      # the output for later use.
       run: |
         DOCKER_ORG="econialabs"
         REPO_NAME="aptos-cli"
@@ -100,17 +102,16 @@ jobs:
           tags"
         BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
         echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
-    - run: "echo ${{ steps.base-url.outputs.url }}"
-#     - name: 'Append ARM images to AMD manifest, remove old ARM images'
-#       run: |
-#         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
-#         if [ ! -z "$tag" ]; then
-#         docker buildx imagetools create --append -t "$tag" "$tag-arm64"
-#         curl -X DELETE \
-#         -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
-#         "${{ steps.base-url.outputs.url }}/$tag-arm64/"
-#         fi
-#         done
+    - name: 'Append ARM images to AMD manifest, remove old ARM images'
+      run: |
+        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
+        if [ ! -z "$tag" ]; then
+        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
+        curl -X DELETE \
+        -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
+        "${{ steps.base-url.outputs.url }}/$tag-arm64/"
+        fi
+        done
 name: 'Build the aptos-cli Docker image and push to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -80,7 +80,7 @@ jobs:
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
-        labels: '${{ steps.metadata.outputs.labels }}'
+        labels: '${{ steps.arm64-metadata.outputs.labels }}'
         platforms: 'linux/arm64'
         push: true
         tags: '${{ steps.arm64-metadata.outputs.tags }}'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -37,6 +37,7 @@ jobs:
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}
+
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
     - id: 'arm64-metadata'
@@ -48,6 +49,7 @@ jobs:
         tags: >
           type=match,pattern=aptos-cli-v(.*),group=1,
           enable=${{ github.event_name == 'push' }}
+
           type=raw,value=${{ github.event.inputs.cli_version }},
           enable=${{ github.event_name == 'workflow_dispatch' }}
     - uses: 'docker/setup-qemu-action@v3'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -90,7 +90,7 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - rune: echo "${{ needs.build.outputs.amd64-tags }}"
+    - run: echo "${{ needs.build.outputs.amd64-tags }}"
 #     - name: 'Append ARM images to AMD manifest, remove old ARM images'
 #       run: |
 #         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -7,8 +7,7 @@
 jobs:
   build:
     outputs:
-      amd64-tags: |
-        ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
+      tags: ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
 #    - uses: 'actions/checkout@v4'
@@ -90,7 +89,7 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - run: echo "${{ needs.build.outputs.amd64-tags }}"
+    - run: echo "${{ needs.build.outputs.tags }}"
 #     - name: 'Append ARM images to AMD manifest, remove old ARM images'
 #       run: |
 #         echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -53,7 +53,8 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Strip -arm64 suffix from CLI version if needed'
+    - id: 'clean-version'
+      name: 'Strip -arm64 suffix from CLI version if needed'
       run: |
         VERSION="${{ steps.metadata.outputs.version }}"
         if [[ "$VERSION" == *-arm64 ]]; then

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -5,8 +5,12 @@
 # cspell:word toolsdirectory
 ---
 jobs:
-  build-amd64:
-    runs-on: 'ubuntu-latest'
+  build:
+    outputs:
+      amd64-tags: |
+        ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
+    runs-on: |
+      ${{ matrix.runner }}
     steps:
     - uses: 'actions/checkout@v4'
     - name: 'Remove unused packages to free up runner disk space'
@@ -29,66 +33,12 @@ jobs:
         sudo apt clean
         sudo apt autoremove -y
         df -h /
-      # yamllint enable rule:indentation
-    - id: 'metadata'
-      uses: 'docker/metadata-action@v5'
-      with:
-        images: 'econialabs/aptos-cli'
-        # yamllint disable rule:empty-lines
-        tags: >
-          type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
-          type=raw,value=${{ github.event.inputs.cli_version }},
-          enable=${{ github.event_name == 'workflow_dispatch' }}
-      # yamllint enable rule:empty-lines
-    - uses: 'docker/setup-buildx-action@v3'
-    - uses: 'docker/login-action@v3'
-      with:
-        password: '${{ secrets.DOCKERHUB_TOKEN }}'
-        username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Push AMD image to Docker Hub'
-      uses: 'docker/build-push-action@v6'
-      with:
-        build-args: |
-          CLI_VERSION=${{ steps.metadata.outputs.version }}
-        cache-from: 'type=gha'
-        cache-to: 'type=gha,mode=max'
-        context: '.'
-        file: 'src/aptos-cli/Dockerfile'
-        platforms: 'linux/amd64'
-        push: true
-        tags: '${{ steps.metadata.outputs.tags }}'
-  build-arm64:
-    runs-on: 'ubuntu-24.04-arm'
-    steps:
-    - uses: 'actions/checkout@v4'
-    - name: 'Remove unused packages to free up runner disk space'
-      # yamllint disable rule:indentation
-      run: |
-        sudo rm -rf \
-          "$AGENT_TOOLSDIRECTORY" \
-          /opt/google/chrome \
-          /opt/microsoft/msedge \
-          /opt/microsoft/powershell \
-          /opt/pipx \
-          /usr/lib/mono \
-          /usr/local/julia* \
-          /usr/local/lib/android \
-          /usr/local/lib/node_modules \
-          /usr/local/share/chromium \
-          /usr/local/share/powershell \
-          /usr/share/dotnet \
-          /usr/share/swift
-        sudo apt clean
-        sudo apt autoremove -y
-        df -h /
-      # yamllint enable rule:indentation
+    # yamllint enable rule:indentation
     - id: 'metadata'
       uses: 'docker/metadata-action@v5'
       with:
         flavor: |
-          suffix=-arm64,onlatest=true
+          ${{ matrix.flavor }}
         images: 'econialabs/aptos-cli'
         # yamllint disable rule:empty-lines
         tags: >
@@ -103,22 +53,32 @@ jobs:
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - name: 'Push ARM image to Docker Hub'
+    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
       uses: 'docker/build-push-action@v6'
       with:
         build-args: |
-          CLI_VERSION=${{ steps.metadata.outputs.version }}
+          CLI_VERSION=${{
+          replace(steps.metadata.outputs.version, '-arm64', '')
+          }}
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
         file: 'src/aptos-cli/Dockerfile'
-        platforms: 'linux/arm64'
+        platforms: 'linux/${{ matrix.arch }}'
         push: true
         tags: '${{ steps.metadata.outputs.tags }}'
+    strategy:
+      matrix:
+        include:
+        - arch: 'amd64'
+          flavor: null
+          runner: 'ubuntu-latest'
+        - arch: 'arm64'
+          flavor: |
+            suffix=-arm64,onlatest=true
+          runner: 'ubuntu-24.04-arm'
   update-manifest:
-    needs:
-    - 'build-amd64'
-    - 'build-arm64'
+    needs: 'build'
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'docker/setup-buildx-action@v3'
@@ -128,7 +88,7 @@ jobs:
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - name: 'Append ARM images to AMD manifest'
       run: |
-        echo "${{ needs.build-amd64.outputs.tags }}" | while read -r tag; do
+        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
         if [ ! -z "$tag" ]; then
         docker buildx imagetools create --append -t "$tag" "${tag}-arm64"
         fi

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -5,6 +5,13 @@
 # cspell:word toolsdirectory
 ---
 jobs:
+  amd-test:
+    runs-on: 'ubuntu-latest'
+    - run: 'echo "Hello, AMD!"'
+  arm-test:
+    runs-on: 'ubuntu-24.04-arm'
+    steps:
+    - run: 'echo "Hello, ARM!"'
   build:
     outputs:
       amd64-tags: |

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -67,7 +67,7 @@ jobs:
         file: 'src/aptos-cli/Dockerfile'
         push: true
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: 'linux/arm64'
+        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
         tags: '${{ steps.metadata.outputs.tags }}'
         build-args: |
           CLI_VERSION=${{ steps.metadata.outputs.version }}

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -16,16 +16,6 @@ repos:
 -
   hooks:
   -
-    args:
-    - '--config-file'
-    - 'cfg/yamllint-config.yaml'
-    - '--strict'
-    id: 'yamllint'
-  repo: 'https://github.com/adrienverge/yamllint'
-  rev: 'v1.34.0'
--
-  hooks:
-  -
     entry: './src/sh/ensure-shebang.sh'
     id: 'ensure-shebang'
     language: 'script'

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -6,78 +6,62 @@
 # cspell:word rustflags
 
 ARG BUILDER_VERSION=1.1.0
-ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
+# Default to compile using as many logical CPUs as possible.
+ARG CARGO_BUILD_JOBS=-1
+ARG CLI_BINARY=aptos-core/target/cli/aptos
 ARG CLI_VERSION
+ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
-ARG CLI_BINARY=app/aptos-core/target/cli/aptos
 
-# Configure base image with buildtime dependencies.
-FROM econialabs/rust-builder:$BUILDER_VERSION AS base
-WORKDIR /app
-RUN apt-get update                                \
-    && apt-get install --no-install-recommends -y \
-        libudev-dev=252*                          \
-        build-essential=12*                       \
-        libclang-dev=1:14*                        \
-        libpq-dev=15*                             \
-        libssl-dev=3*                             \
-        libdw-dev=0.188*                          \
-        pkg-config=1.8*                           \
-        lld=1:14*                                 \
-        curl=7*                                   \
-    && rm -rf /var/lib/apt/lists/*
-
-# Plan build recipe, updating a known offending dependency.
-FROM base AS planner
-ARG GIT_REPO
-ARG GIT_TAG
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
-WORKDIR /app/aptos-core
-RUN cargo update -p time --precise "0.3.35" && cargo chef prepare --bin aptos
-
-# Cache crate dependencies.
-FROM base AS builder
+# Install buildtime dependencies.
+FROM econialabs/rust-builder:$BUILDER_VERSION AS builder
+ARG CARGO_BUILD_JOBS
 ARG CLI_BINARY
 ARG GIT_REPO
 ARG GIT_TAG
-COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json
-WORKDIR /app/aptos-core
-RUN cargo chef cook --bin aptos --profile cli
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libudev-dev=252* \
+        build-essential=12 \
+        libclang-dev=1:14* \
+        libpq-dev=15* \
+        libssl-dev=3* \
+        libdw-dev=0.188* \
+        pkg-config=1.8* \
+        lld=1:14* \
+        curl=7* \
+    && rm -rf /var/lib/apt/lists/*
 
-# Clone the repo one level deeper to preserve build outputs directory layout,
-# then move all its files into working directory for compilation (with updated
-# known offending dependency) and eventual binary stripping.
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1 \
-    && cp -r aptos-core/* . && rm -rf aptos-core    \
-    && cargo update -p time --precise "0.3.35"
-RUN cargo build --bin aptos --jobs 1 --profile cli
+# Clone aptos-core, update a known offending dependency, build the CLI binary
+# using specified number of parallel jobs, then strip it.
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+WORKDIR /aptos-core
+RUN cargo update --package time --precise "0.3.35" \
+    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
 WORKDIR /
 RUN strip -s "$CLI_BINARY"
 
-# Install runtime dependencies, copy binary, set assorted container configs.
+# Install runtime dependencies, copy over binary.
 FROM debian:bookworm-slim AS runtime
 ARG CLI_BINARY
-WORKDIR /app
-RUN apt-get update                                \
+RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        ca-certificates=2023*                     \
-        curl=7*                                   \
-        git=1:2.39*                               \
-        jq=1.6*                                   \
+        ca-certificates=2023* \
+        curl=7* \
+        git=1:2.39* \
+        jq=1.6* \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=/usr/local/bin:$PATH
 COPY --from=builder $CLI_BINARY /usr/local/bin
+
+# Copy over healthcheck script, make it executable so it can be run.
+WORKDIR /
 COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
-RUN chmod +x /app/sh/healthcheck.sh
-
-STOPSIGNAL SIGKILL
-
-HEALTHCHECK            \
-    --interval=5s      \
-    --timeout=5s       \
+RUN chmod +x sh/healthcheck.sh
+HEALTHCHECK \
+    --interval=5s \
+    --timeout=5s \
     --start-period=60s \
-    --retries=10       \
+    --retries=10 \
     CMD [ "bash", "sh/healthcheck.sh" ]
 
 # Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
@@ -85,11 +69,13 @@ HEALTHCHECK            \
 # This is because the CLI is assumed to not be running inside a container, and
 # issues can arise on Windows when binding to 0.0.0.0.
 # See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
-ENTRYPOINT [              \
-    "aptos",              \
-    "node",               \
-    "run-localnet",       \
+ENTRYPOINT [ \
+    "aptos", \
+    "node", \
+    "run-localnet", \
     "--with-indexer-api", \
-    "--bind-to",          \
-    "0.0.0.0"             \
+    "--bind-to", \
+    "0.0.0.0" \
 ]
+
+STOPSIGNAL SIGKILL

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -1,8 +1,3 @@
-# Specifying package versions in `apt-get` commands can cause
-# multi-architecture builds to fail, so the hadolint rule for
-# version specification is disabled in this file.
-# hadolint global ignore=DL3008
-# cspell:word hadolint
 # cspell:word libudev
 # cspell:word libclang
 # cspell:word libpq
@@ -10,70 +5,74 @@
 # cspell:word localnet
 # cspell:word rustflags
 
+ARG BUILDER_VERSION=1.1.0
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG CLI_VERSION
 ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
 ARG CLI_BINARY=/aptos-core/target/cli/aptos
 
-FROM rust:1-bookworm AS aptos-cli
+# Configure base image with buildtime dependencies.
+FROM econialabs/rust-builder:$BUILDER_VERSION AS base
+WORKDIR /app
+RUN apt-get update                                \
+    && apt-get install --no-install-recommends -y \
+        libudev-dev=252*                          \
+        build-essential=12*                       \
+        libclang-dev=1:14*                        \
+        libpq-dev=15*                             \
+        libssl-dev=3*                             \
+        libdw-dev=0.188*                          \
+        pkg-config=1.8*                           \
+        lld=1:14*                                 \
+        curl=7*                                   \
+    && rm -rf /var/lib/apt/lists/*
 
+# Plan build recipe.
+FROM base AS planner
 ARG GIT_REPO
 ARG GIT_TAG
-ARG CLI_BINARY
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+WORKDIR /app/aptos-core
+RUN cargo chef prepare --bin aptos --package aptos --profile cli
 
-# Set environment variables to improve build compatibility.
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Cache crate dependencies, compile the binary, strip it to reduce its size.
+FROM base AS builder
+ARG GIT_REPO
+ARG GIT_TAG
+COPY --from=planner /app/aptos-core/recipe.json recipe.json
+RUN cargo chef cook --bin aptos --package aptos --profile cli
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 ENV RUSTFLAGS="--cfg tokio_unstable"
-
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1  \
-    && apt-get update                                \
-    && apt-get install --no-install-recommends -y    \
-        libudev-dev=252*                             \
-        build-essential=12*                          \
-        libclang-dev=1:14*                           \
-        libpq-dev=15*                                \
-        libssl-dev=3*                                \
-        libdw-dev=0.188*                             \
-        pkg-config=1.8*                              \
-        lld=1:14*                                    \
-        curl=7*                                      \
-    && rm -rf /var/lib/apt/lists/*
-
-# Resolve outdated lockfile from upstream tag, build the binary,
-# and strip it to reduce its size.
-RUN cargo update --manifest-path /aptos-core/Cargo.toml  \
-    && cargo build                                       \
-        --bin aptos                                      \
-        --manifest-path /aptos-core/Cargo.toml           \
-        --profile cli                                    \
+RUN cargo build                                \
+        --bin aptos                            \
+        --manifest-path /aptos-core/Cargo.toml \
+        --profile cli                          \
     && strip -s $CLI_BINARY
 
-FROM ubuntu:noble
+# Install runtime dependencies, copy binary, set assorted container configs.
+FROM debian:bookworm-slim AS runtime
 ARG CLI_BINARY
-
-RUN apt-get update                                 \
-    && apt-get install --no-install-recommends -y  \
-        ca-certificates=2024*                      \
-        curl=8.5*                                  \
-        git=1:2.43*                                \
-        jq=1.7*                                    \
+WORKDIR /app
+RUN apt-get update                                \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates=2023*                     \
+        curl=7*                                   \
+        git=1:2.39*                               \
+        jq=1.6*                                   \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-
 ENV PATH=/usr/local/bin:$PATH
-COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
-
+COPY --from=builder $CLI_BINARY /usr/local/bin
 COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
 RUN chmod +x /app/sh/healthcheck.sh
 
 STOPSIGNAL SIGKILL
 
-HEALTHCHECK                                   \
-    --interval=5s                             \
-    --timeout=5s                              \
-    --start-period=60s                        \
-    --retries=10                              \
+HEALTHCHECK            \
+    --interval=5s      \
+    --timeout=5s       \
+    --start-period=60s \
+    --retries=10       \
     CMD [ "bash", "sh/healthcheck.sh" ]
 
 # Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
@@ -81,11 +80,11 @@ HEALTHCHECK                                   \
 # This is because the CLI is assumed to not be running inside a container, and
 # issues can arise on Windows when binding to 0.0.0.0.
 # See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
-ENTRYPOINT [               \
-    "aptos",               \
-    "node",                \
-    "run-localnet",        \
-    "--with-indexer-api",  \
-    "--bind-to",           \
-    "0.0.0.0"              \
+ENTRYPOINT [              \
+    "aptos",              \
+    "node",               \
+    "run-localnet",       \
+    "--with-indexer-api", \
+    "--bind-to",          \
+    "0.0.0.0"             \
 ]

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -33,8 +33,7 @@ ARG GIT_REPO
 ARG GIT_TAG
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
-RUN cargo update -p time --precise "0.3.35"
-RUN cargo chef prepare --bin aptos
+RUN cargo update -p time --precise "0.3.35" && cargo chef prepare --bin aptos
 
 # Cache crate dependencies.
 FROM base AS builder
@@ -44,15 +43,15 @@ COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json
 WORKDIR /app/aptos-core
 RUN cargo chef cook --bin aptos --profile cli
 
-# Clone the repo one level deeper, then move all its files into working
-# directory for compilation (with updated known offending dependency) and
-# binary stripping.
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
-RUN cp -r aptos-core/* . && rm -rf aptos-core
-RUN cargo update -p time --precise "0.3.35"
+# Clone the repo one level deeper to preserve build outputs directory layout,
+# then move all its files into working directory for compilation (with updated
+# known offending dependency) and eventual binary stripping.
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1 \
+    && cp -r aptos-core/* . && rm -rf aptos-core    \
+    && cargo update -p time --precise "0.3.35"
 RUN cargo build --bin aptos --jobs 1 --profile cli
 WORKDIR /
-RUN strip -s $CLI_BINARY
+RUN strip -s "$CLI_BINARY"
 
 # Install runtime dependencies, copy binary, set assorted container configs.
 FROM debian:bookworm-slim AS runtime

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -33,9 +33,9 @@ ARG GIT_REPO
 ARG GIT_TAG
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
-ENV RUSTFLAGS="--cfg tokio_unstable"
-ENV RUSTUP_TOOLCHAIN=stable
-ENV RUST_VERSION_OVERRIDE=stable
+# ENV RUSTFLAGS="--cfg tokio_unstable"
+# ENV RUSTUP_TOOLCHAIN=stable
+# ENV RUST_VERSION_OVERRIDE=stable
 # RUN cargo update
 RUN cargo chef prepare --bin aptos
 
@@ -45,19 +45,20 @@ ARG GIT_REPO
 ARG GIT_TAG
 COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json
 WORKDIR /app/aptos-core
-ENV RUSTFLAGS="--cfg tokio_unstable"
-ENV RUSTUP_TOOLCHAIN=stable
-ENV RUST_VERSION_OVERRIDE=stable
+# ENV RUSTFLAGS="--cfg tokio_unstable"
+# ENV RUSTUP_TOOLCHAIN=stable
+# ENV RUST_VERSION_OVERRIDE=stable
 # RUN cargo update
-RUN cargo chef cook --bin aptos --package aptos --profile cli
+RUN cargo chef cook --bin aptos --profile cli
 
 # Clone the repo one level deeper, then move all its files into working
 # directory for compilation and binary stripping.
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 RUN cp -r aptos-core/* . && rm -rf aptos-core
-ENV RUSTFLAGS="--cfg tokio_unstable"
-ENV RUSTUP_TOOLCHAIN=stable
-ENV RUST_VERSION_OVERRIDE=stable
+# ENV RUSTFLAGS="--cfg tokio_unstable"
+# ENV RUSTUP_TOOLCHAIN=stable
+# ENV RUST_VERSION_OVERRIDE=stable
+# RUN cargo update
 # RUN cargo update
 RUN cargo build --bin aptos --profile cli
 WORKDIR /

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -50,7 +50,7 @@ RUN cargo chef cook --bin aptos --profile cli
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 RUN cp -r aptos-core/* . && rm -rf aptos-core
 RUN cargo update -p time --precise "0.3.35"
-RUN cargo build --bin aptos --profile cli
+RUN cargo build --bin aptos --jobs 1 --profile cli
 WORKDIR /
 RUN strip -s $CLI_BINARY
 

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILDER_VERSION=1.1.0
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG CLI_VERSION
 ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
-ARG CLI_BINARY=/aptos-core/target/cli/aptos
+ARG CLI_BINARY=app/aptos-core/target/cli/aptos
 
 # Configure base image with buildtime dependencies.
 FROM econialabs/rust-builder:$BUILDER_VERSION AS base
@@ -33,27 +33,35 @@ ARG GIT_REPO
 ARG GIT_TAG
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
-ENV RUSTUP_TOOLCHAIN=stable
-ENV RUST_VERSION_OVERRIDE=stable
-RUN cargo update && cargo chef prepare --bin aptos
-
-# Cache crate dependencies, compile the binary with updated lockfile, strip it
-# to reduce its size.
-FROM base AS builder
-ARG GIT_REPO
-ARG GIT_TAG
-COPY --from=planner /app/aptos-core/recipe.json recipe.json
-RUN cargo chef cook --bin aptos --package aptos --profile cli
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 ENV RUSTFLAGS="--cfg tokio_unstable"
 ENV RUSTUP_TOOLCHAIN=stable
 ENV RUST_VERSION_OVERRIDE=stable
-RUN cargo update \
-    && cargo build                             \
-        --bin aptos                            \
-        --manifest-path /aptos-core/Cargo.toml \
-        --profile cli                          \
-    && strip -s $CLI_BINARY
+# RUN cargo update
+RUN cargo chef prepare --bin aptos
+
+# Cache crate dependencies.
+FROM base AS builder
+ARG GIT_REPO
+ARG GIT_TAG
+COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json
+WORKDIR /app/aptos-core
+ENV RUSTFLAGS="--cfg tokio_unstable"
+ENV RUSTUP_TOOLCHAIN=stable
+ENV RUST_VERSION_OVERRIDE=stable
+# RUN cargo update
+RUN cargo chef cook --bin aptos --package aptos --profile cli
+
+# Clone the repo one level deeper, then move all its files into working
+# directory for compilation and binary stripping.
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+RUN cp -r aptos-core/* . && rm -rf aptos-core
+ENV RUSTFLAGS="--cfg tokio_unstable"
+ENV RUSTUP_TOOLCHAIN=stable
+ENV RUST_VERSION_OVERRIDE=stable
+# RUN cargo update
+RUN cargo build --bin aptos --profile cli
+WORKDIR /
+RUN strip -s $CLI_BINARY
 
 # Install runtime dependencies, copy binary, set assorted container configs.
 FROM debian:bookworm-slim AS runtime

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -22,7 +22,7 @@ ARG GIT_TAG
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         libudev-dev=252* \
-        build-essential=12 \
+        build-essential=12* \
         libclang-dev=1:14* \
         libpq-dev=15* \
         libssl-dev=3* \

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -27,17 +27,12 @@ RUN apt-get update                                \
         curl=7*                                   \
     && rm -rf /var/lib/apt/lists/*
 
-# Plan build recipe using updated lockfile.
+# Plan build recipe, updating a known offending dependency.
 FROM base AS planner
 ARG GIT_REPO
 ARG GIT_TAG
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
-# ENV RUSTFLAGS="--cfg tokio_unstable"
-# ENV RUSTUP_TOOLCHAIN=stable
-# ENV RUST_VERSION_OVERRIDE=stable
-# RUN cargo update
-# RUN cargo update -p time --precise "0.3.35"
 RUN cargo update -p time --precise "0.3.35"
 RUN cargo chef prepare --bin aptos
 
@@ -47,23 +42,13 @@ ARG GIT_REPO
 ARG GIT_TAG
 COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json
 WORKDIR /app/aptos-core
-# ENV RUSTFLAGS="--cfg tokio_unstable"
-# ENV RUSTUP_TOOLCHAIN=stable
-# ENV RUST_VERSION_OVERRIDE=stable
-# RUN cargo update
-# RUN cargo update -p time --precise "0.3.35"
 RUN cargo chef cook --bin aptos --profile cli
 
 # Clone the repo one level deeper, then move all its files into working
-# directory for compilation and binary stripping.
+# directory for compilation (with updated known offending dependency) and
+# binary stripping.
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 RUN cp -r aptos-core/* . && rm -rf aptos-core
-# ENV RUSTFLAGS="--cfg tokio_unstable"
-# ENV RUSTUP_TOOLCHAIN=stable
-# ENV RUST_VERSION_OVERRIDE=stable
-# RUN cargo update
-# RUN cargo update
-# RUN cargo update -p time --precise "0.3.35"
 RUN cargo update -p time --precise "0.3.35"
 RUN cargo build --bin aptos --profile cli
 WORKDIR /

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -37,6 +37,7 @@ RUN cargo update -p time --precise "0.3.35" && cargo chef prepare --bin aptos
 
 # Cache crate dependencies.
 FROM base AS builder
+ARG CLI_BINARY
 ARG GIT_REPO
 ARG GIT_TAG
 COPY --from=planner /app/aptos-core/recipe.json aptos-core/recipe.json

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -33,7 +33,9 @@ ARG GIT_REPO
 ARG GIT_TAG
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
-RUN cargo chef prepare --bin aptos --package aptos --profile cli
+ENV RUSTUP_TOOLCHAIN=stable
+ENV RUST_VERSION_OVERRIDE=stable
+RUN cargo chef prepare --bin aptos
 
 # Cache crate dependencies, compile the binary, strip it to reduce its size.
 FROM base AS builder
@@ -43,6 +45,8 @@ COPY --from=planner /app/aptos-core/recipe.json recipe.json
 RUN cargo chef cook --bin aptos --package aptos --profile cli
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 ENV RUSTFLAGS="--cfg tokio_unstable"
+ENV RUSTUP_TOOLCHAIN=stable
+ENV RUST_VERSION_OVERRIDE=stable
 RUN cargo build                                \
         --bin aptos                            \
         --manifest-path /aptos-core/Cargo.toml \

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
 # using specified number of parallel jobs, then strip it.
 RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /aptos-core
-RUN cargo update --package time --precise "0.3.35" \
+RUN cargo update --package time \
     && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
 WORKDIR /
 RUN strip -s "$CLI_BINARY"

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -37,6 +37,8 @@ WORKDIR /app/aptos-core
 # ENV RUSTUP_TOOLCHAIN=stable
 # ENV RUST_VERSION_OVERRIDE=stable
 # RUN cargo update
+# RUN cargo update -p time --precise "0.3.35"
+RUN cargo update -p time --precise "0.3.35"
 RUN cargo chef prepare --bin aptos
 
 # Cache crate dependencies.
@@ -49,6 +51,7 @@ WORKDIR /app/aptos-core
 # ENV RUSTUP_TOOLCHAIN=stable
 # ENV RUST_VERSION_OVERRIDE=stable
 # RUN cargo update
+# RUN cargo update -p time --precise "0.3.35"
 RUN cargo chef cook --bin aptos --profile cli
 
 # Clone the repo one level deeper, then move all its files into working
@@ -60,6 +63,8 @@ RUN cp -r aptos-core/* . && rm -rf aptos-core
 # ENV RUST_VERSION_OVERRIDE=stable
 # RUN cargo update
 # RUN cargo update
+# RUN cargo update -p time --precise "0.3.35"
+RUN cargo update -p time --precise "0.3.35"
 RUN cargo build --bin aptos --profile cli
 WORKDIR /
 RUN strip -s $CLI_BINARY

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update                                \
         curl=7*                                   \
     && rm -rf /var/lib/apt/lists/*
 
-# Plan build recipe.
+# Plan build recipe using updated lockfile.
 FROM base AS planner
 ARG GIT_REPO
 ARG GIT_TAG
@@ -35,9 +35,10 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 WORKDIR /app/aptos-core
 ENV RUSTUP_TOOLCHAIN=stable
 ENV RUST_VERSION_OVERRIDE=stable
-RUN cargo chef prepare --bin aptos
+RUN cargo update && cargo chef prepare --bin aptos
 
-# Cache crate dependencies, compile the binary, strip it to reduce its size.
+# Cache crate dependencies, compile the binary with updated lockfile, strip it
+# to reduce its size.
 FROM base AS builder
 ARG GIT_REPO
 ARG GIT_TAG
@@ -47,7 +48,8 @@ RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
 ENV RUSTFLAGS="--cfg tokio_unstable"
 ENV RUSTUP_TOOLCHAIN=stable
 ENV RUST_VERSION_OVERRIDE=stable
-RUN cargo build                                \
+RUN cargo update \
+    && cargo build                             \
         --bin aptos                            \
         --manifest-path /aptos-core/Cargo.toml \
         --profile cli                          \

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -86,7 +86,7 @@ docker buildx build \
   .
 ```
 
-## Resouce consumption
+## Resource consumption
 
 Since the `aptos` binary has so many dependencies, compilation may fail due to
 resource exhaustion unless adequate measures are taken.

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -27,7 +27,7 @@ RUN aptos --version
 # > aptos 6.0.2
 ```
 
-## Building the image and pushing it to the `econialabs` Docker hub
+## Building the image and pushing it to the `econialabs` Docker Hub registry
 
 To build a Docker image with a specific version of the Aptos CLI, simply push
 the corresponding version tag to GitHub to trigger the GitHub workflow that

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -58,8 +58,7 @@ Since the action strips the `v` when parsing the `ARG CLI_VERSION` value.
 
 ## Multi-architecture support
 
-Currently the GitHub action triggers builds for `amd64`, then once it has
-finished, an `amd64` build.
+Currently the GitHub action triggers builds for `arm64` and `amd64`.
 
 ## Building it yourself locally
 

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -10,21 +10,21 @@ The Aptos CLI is available for various platforms and architectures as a
 standalone executable; however, there isn't a ready-to-use Docker image for the
 `aarch64` processor architecture (labeled as `linux/arm64/v8` in Docker).
 
-This architecture is particularly significant, as it's used in the arm-based
+This architecture is particularly significant, as it's used in the ARM-based
 Apple silicon found in newer Macbooks.
 
 The image built from this Dockerfile serves to address this gap and provide a
 solution for users working with these systems.
 
 It builds an image of the `aptos` CLI for `linux/arm64` and `linux/amd64`, with
-the CLI version corresponding directly Docker image tag:
+the CLI version corresponding directly to the Docker image tag:
 
 ```Dockerfile
-# Uses the aptos CLI, version 4.0.0
-FROM econialabs/aptos-cli:4.0.0
+# Uses the aptos CLI, version 6.0.2
+FROM econialabs/aptos-cli:6.0.2
 
 RUN aptos --version
-# > aptos 4.0.0
+# > aptos 6.0.2
 ```
 
 ## Building the image and pushing it to the `econialabs` Docker hub
@@ -34,12 +34,12 @@ the corresponding version tag to GitHub to trigger the GitHub workflow that
 builds the image in CI:
 
 ```shell
-git tag aptos-cli-v4.0.0
+git tag aptos-cli-vX.Y.Z
 ```
 
 This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos`
 CLI Docker image and subsequently push it to the `econialabs` Dockerhub
-repository as `econialabs/aptos-cli:4.0.0`.
+repository as `econialabs/aptos-cli:X.Y.Z`.
 
 ## Triggering the workflow manually
 
@@ -48,17 +48,18 @@ The action is also set to trigger manually on `workflow_dispatch`.
 You will be prompted to input the version, which will work with both of the
 following formats:
 
-`cli_version: v4.0.0`
+`cli_version: vX.Y.Z`
 
 or
 
-`cli_version: 4.0.0`
+`cli_version: X.Y.Z`
 
-Since the Dockerfile strips the `v` when parsing the `ARG CLI_VERSION` value.
+Since the action strips the `v` when parsing the `ARG CLI_VERSION` value.
 
 ## Multi-architecture support
 
-Currently the GitHub action triggers builds for `arm64` and `amd64`.
+Currently the GitHub action triggers builds for `amd64`, then once it has
+finished, an `amd64` build.
 
 ## Building it yourself locally
 
@@ -74,7 +75,7 @@ A simple `bash` script for this process might be something like:
 git_root=$(git rev-parse --show-toplevel)
 
 username=YOUR_DOCKERHUB_USERNAME
-version=v4.0.0
+version=v6.0.2
 
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
@@ -84,3 +85,18 @@ docker buildx build \
   --push \
   .
 ```
+
+## Resouce consumption
+
+Since the `aptos` binary has so many dependencies, compilation may fail due to
+resource exhaustion unless adequate measures are taken.
+
+If you are building locally then you should be able to prevent failure by simply
+increasing your [Docker Desktop resources], in particular `CPU limit` and
+`Memory limit`.
+
+Alternatively, you can pass [`CARGO_BUILD_JOBS`] as a `build-arg` to limit the
+number of parallel compilation processes.
+
+[docker desktop resources]: https://docs.docker.com/desktop/settings-and-maintenance/settings/#advanced
+[`cargo_build_jobs`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Changes

1. Update CLI dockerfile to use `rust-builder` image for consistency with other images (but do not use `cargo-chef` since it is an external Rust project).
2. Add `--jobs` build argument to prevent memory overflow during compilation.
3. Update CI to use new ARM runner.
4. Remove duplicate `yamllint` definition in `pre-commit` config.
5. Update spacing before `\` to conform with Dockerfile example to avoid having to dedent multiple lines on deps change.
6. Simplify Dockerfile build commands as applicable.
7. Make minor changes to README, and add in a section about resource exhaustion.

# Testing

- [x] Compile locally on `arm64` (note I was able to do this in less than 10 minutes by simply increasing my Docker Desktop resources per the README)
- [x] Push tags to this branch to verify the build
