### PR TITLE
[ECO-2750] Clean up Aptos CLI builder CI

### DIFF
--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,6 +1,5 @@
 # cspell:word autoremove
 # cspell:word imagetools
-# cspell:word onlatest
 # cspell:word pipx
 # cspell:word toolsdirectory
 ---
@@ -46,7 +45,8 @@ jobs:
         sudo apt autoremove -y
         df -h /
     # yamllint enable rule:indentation
-    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
+    - id: 'build'
+      name: 'Push ${{ matrix.arch }} image to Docker Hub'
       uses: 'docker/build-push-action@v6'
       with:
         build-args: 'CLI_VERSION=${{ needs.metadata.outputs.version }}'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -11,7 +11,7 @@ env:
   GIT_TAG_PREFIX: 'aptos-cli'
 jobs:
   metadata:
-    ouputs:
+    outputs:
       json: '${{ steps.metadata.outputs.json }}'
       version: '${{ steps.metadata.outputs.version }}'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -10,25 +10,6 @@ env:
   DOCKER_REPO: 'econialabs/aptos-cli'
   GIT_TAG_PREFIX: 'aptos-cli'
 jobs:
-  metadata:
-    outputs:
-      json: '${{ steps.metadata.outputs.json }}'
-      version: '${{ steps.metadata.outputs.version }}'
-    runs-on: 'ubuntu-latest'
-    steps:
-    - id: 'metadata'
-      name: 'Extract metadata from git tag or workflow_dispatch input'
-      uses: 'docker/metadata-action@v5'
-      with:
-        images: '${{ env.DOCKER_REPO }}'
-        # yamllint disable rule:empty-lines
-        tags: >
-          type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
-          type=raw,value=${{ github.event.inputs.cli_version }},
-          enable=${{ github.event_name == 'workflow_dispatch' }}
-  # yamllint enable rule:empty-lines
   build:
     needs: 'metadata'
     outputs:
@@ -102,11 +83,29 @@ jobs:
     - name: 'Create multi-architecture image manifest on Docker Hub'
       run: |
         TAG_ARGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' \
-          <<< '${{ needs.metadata.outputs.json }}')
-        docker buildx imagetools create \
-          ${TAG_ARGS} \
-          ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-amd64 }} \
-          ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-arm64 }}
+        <<< '${{ needs.metadata.outputs.json }}')
+        docker buildx imagetools create ${TAG_ARGS} \
+        ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-amd64 }} \
+        ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-arm64 }}
+  metadata:
+    outputs:
+      json: '${{ steps.metadata.outputs.json }}'
+      version: '${{ steps.metadata.outputs.version }}'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'metadata'
+      name: 'Extract metadata from git tag or workflow_dispatch input'
+      uses: 'docker/metadata-action@v5'
+      with:
+        images: '${{ env.DOCKER_REPO }}'
+        # yamllint disable rule:empty-lines
+        tags: >
+          type=match,pattern=aptos-cli-v(.*),group=1,
+          enable=${{ github.event_name == 'push' }}
+
+          type=raw,value=${{ github.event.inputs.cli_version }},
+          enable=${{ github.event_name == 'workflow_dispatch' }}
+# yamllint enable rule:empty-lines
 name: 'Push multi-platform aptos-cli image to Docker Hub'
 'on':
   push:

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -4,14 +4,46 @@
 # cspell:word pipx
 # cspell:word toolsdirectory
 ---
+env:
+  BUILD_CONTEXT: '.'
+  BUILD_FILE: 'src/aptos-cli/Dockerfile'
+  DOCKER_REPO: 'econialabs/aptos-cli'
+  GIT_TAG_PREFIX: 'aptos-cli'
 jobs:
+  metadata:
+    ouputs:
+      json: '${{ steps.metadata.outputs.json }}'
+      version: '${{ steps.metadata.outputs.version }}'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'metadata'
+      name: 'Extract metadata from git tag or workflow_dispatch input'
+      uses: 'docker/metadata-action@v5'
+      with:
+        images: '${{ env.DOCKER_REPO }}'
+        # yamllint disable rule:empty-lines
+        tags: >
+          type=match,pattern=aptos-cli-v(.*),group=1,
+          enable=${{ github.event_name == 'push' }}
+
+          type=raw,value=${{ github.event.inputs.cli_version }},
+          enable=${{ github.event_name == 'workflow_dispatch' }}
+  # yamllint enable rule:empty-lines
   build:
+    needs: 'metadata'
     outputs:
-      amd64-tags: >-
-        ${{ matrix.arch == 'amd64' && steps.metadata.outputs.tags || '' }}
+      digest-amd64: >-
+        ${{ matrix.arch == 'amd64' && steps.build.outputs.digest || '' }}
+      digest-arm64: >-
+        ${{ matrix.arch == 'arm64' && steps.build.outputs.digest || '' }}
     runs-on: '${{ matrix.runner }}'
     steps:
     - uses: 'actions/checkout@v4'
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
+      with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - name: 'Remove unused packages to free up runner disk space'
       # yamllint disable rule:indentation
       run: |
@@ -33,89 +65,49 @@ jobs:
         sudo apt autoremove -y
         df -h /
     # yamllint enable rule:indentation
-    - id: 'metadata'
-      uses: 'docker/metadata-action@v5'
+    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
+      uses: 'docker/build-push-action@v6'
       with:
-        flavor: |
-          ${{ matrix.flavor }}
-        images: 'econialabs/aptos-cli'
-        # yamllint disable rule:empty-lines
-        tags: >
-          type=match,pattern=aptos-cli-v(.*),group=1,
-          enable=${{ github.event_name == 'push' }}
-
-          type=raw,value=${{ github.event.inputs.cli_version }},
-          enable=${{ github.event_name == 'workflow_dispatch' }}
-      # yamllint enable rule:empty-lines
+        build-args: 'CLI_VERSION=${{ needs.metadata.outputs.version }}'
+        cache-from: 'type=gha'
+        cache-to: 'type=gha,mode=max'
+        context: '${{ env.BUILD_CONTEXT }}'
+        file: '${{ env.BUILD_FILE }}'
+        outputs: 'name=${{ env.DOCKER_REPO }},push-by-digest=true,type=image'
+        platforms: 'linux/${{ matrix.arch }}'
+        push: true
+    strategy:
+      matrix:
+        include:
+        - arch: 'amd64'
+          runner: 'ubuntu-latest'
+        - arch: 'arm64'
+          runner: 'ubuntu-24.04-arm'
+  create-manifest:
+    needs:
+    - 'build'
+    - 'metadata'
+    runs-on: 'ubuntu-latest'
+    steps:
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
       with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - id: 'clean-version'
-      name: 'Strip -arm64 suffix from CLI version if needed'
-      run: |
-        VERSION="${{ steps.metadata.outputs.version }}"
-        if [[ "$VERSION" == *-arm64 ]]; then
-        VERSION="${VERSION%-arm64}"
-        fi
-        echo "CLI_VERSION_CLEANED=$VERSION" >> "$GITHUB_OUTPUT"
-    - name: 'Push ${{ matrix.arch }} image to Docker Hub'
-      uses: 'docker/build-push-action@v6'
+    - id: 'metadata'
+      uses: 'docker/metadata-action@v5'
       with:
-        build-args: |
-          CLI_VERSION=${{ steps.clean-version.outputs.CLI_VERSION_CLEANED }}
-        cache-from: 'type=gha'
-        cache-to: 'type=gha,mode=max'
-        context: '.'
-        file: 'src/aptos-cli/Dockerfile'
-        platforms: 'linux/${{ matrix.arch }}'
-        push: true
-        tags: '${{ steps.metadata.outputs.tags }}'
-    strategy:
-      matrix:
-        include:
-        - arch: 'amd64'
-          flavor: null
-          runner: 'ubuntu-latest'
-        - arch: 'arm64'
-          flavor: |
-            suffix=-arm64,onlatest=true
-          runner: 'ubuntu-24.04-arm'
-  update-manifest:
-    needs: 'build'
-    runs-on: 'ubuntu-latest'
-    steps:
-    - uses: 'docker/login-action@v3'
-      with:
-        password: '${{ secrets.DOCKERHUB_TOKEN }}'
-        username: '${{ secrets.DOCKERHUB_USERNAME }}'
-    - id: 'base-url'
-      # Use `tr` to remove whitespace from the constructed URL before saving
-      # the output for later use.
+        images: '${{ env.DOCKER_REPO }}'
+        tags: 'type=match,pattern=${{ env.GIT_TAG_PREFIX }}-v(.*),group=1'
+    - name: 'Create multi-architecture image manifest on Docker Hub'
       run: |
-        DOCKER_ORG="econialabs"
-        REPO_NAME="aptos-cli"
-        BASE_URL="https://hub.docker.com/v2/repositories/\
-        ${DOCKER_ORG}/\
-        ${REPO_NAME}/\
-        tags"
-        BASE_URL=$(echo "$BASE_URL" | tr -d ' ')
-        echo "url=$BASE_URL" >> "$GITHUB_OUTPUT"
-    - name: 'Append ARM images to AMD manifest, remove old ARM images'
-      # Loop over all the AMD64 tags and append the ARM64 tags to the manifest,
-      # then delete the old ARM64 tags from Docker Hub.
-      run: |
-        echo "${{ needs.build.outputs.amd64-tags }}" | while read -r tag; do
-        if [ ! -z "$tag" ]; then
-        docker buildx imagetools create --append -t "$tag" "$tag-arm64"
-        VERSION=$(echo "$tag" | cut -d':' -f2)
-        curl -X DELETE \
-        -H "Authorization: JWT ${{ secrets.DOCKERHUB_TOKEN }}" \
-        "${{ steps.base-url.outputs.url }}/${VERSION}-arm64/"
-        fi
-        done
-name: 'Build the aptos-cli Docker image and push to Docker Hub'
+        TAG_ARGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' \
+          <<< '${{ needs.metadata.outputs.json }}')
+        docker buildx imagetools create \
+          ${TAG_ARGS} \
+          ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-amd64 }} \
+          ${{ env.DOCKER_REPO }}@${{ needs.build.outputs.digest-arm64 }}
+name: 'Push multi-platform aptos-cli image to Docker Hub'
 'on':
   push:
     tags:
@@ -124,7 +116,7 @@ name: 'Build the aptos-cli Docker image and push to Docker Hub'
     inputs:
       cli_version:
         description: >-
-          Aptos CLI version to build, for example, 4.0.0
+          Aptos CLI version to build, for example, 6.0.2
         required: true
         type: 'string'
 ...

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -15,67 +15,67 @@ ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
 
 # Install buildtime dependencies.
 FROM econialabs/rust-builder:$BUILDER_VERSION AS builder
-####ARG CARGO_BUILD_JOBS
-####ARG CLI_BINARY
-####ARG GIT_REPO
-####ARG GIT_TAG
-####RUN apt-get update \
-####    && apt-get install --no-install-recommends -y \
-####        libudev-dev=252* \
-####        build-essential=12* \
-####        libclang-dev=1:14* \
-####        libpq-dev=15* \
-####        libssl-dev=3* \
-####        libdw-dev=0.188* \
-####        pkg-config=1.8* \
-####        lld=1:14* \
-####        curl=7* \
-####    && rm -rf /var/lib/apt/lists/*
+ARG CARGO_BUILD_JOBS
+ARG CLI_BINARY
+ARG GIT_REPO
+ARG GIT_TAG
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libudev-dev=252* \
+        build-essential=12* \
+        libclang-dev=1:14* \
+        libpq-dev=15* \
+        libssl-dev=3* \
+        libdw-dev=0.188* \
+        pkg-config=1.8* \
+        lld=1:14* \
+        curl=7* \
+    && rm -rf /var/lib/apt/lists/*
 
-##### Clone aptos-core, update a known offending dependency, build the CLI binary
-##### using specified number of parallel jobs, then strip it.
-####RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
-####WORKDIR /aptos-core
-####RUN cargo update --package time \
-####    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
-####WORKDIR /
-####RUN strip -s "$CLI_BINARY"
+# Clone aptos-core, update a known offending dependency, build the CLI binary
+# using specified number of parallel jobs, then strip it.
+RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+WORKDIR /aptos-core
+RUN cargo update --package time \
+    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
+WORKDIR /
+RUN strip -s "$CLI_BINARY"
 
-##### Install runtime dependencies, copy over binary.
-####FROM debian:bookworm-slim AS runtime
-####ARG CLI_BINARY
-####RUN apt-get update \
-####    && apt-get install --no-install-recommends -y \
-####        ca-certificates=2023* \
-####        curl=7* \
-####        git=1:2.39* \
-####        jq=1.6* \
-####    && rm -rf /var/lib/apt/lists/*
-####COPY --from=builder $CLI_BINARY /usr/local/bin
+# Install runtime dependencies, copy over binary.
+FROM debian:bookworm-slim AS runtime
+ARG CLI_BINARY
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates=2023* \
+        curl=7* \
+        git=1:2.39* \
+        jq=1.6* \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder $CLI_BINARY /usr/local/bin
 
-##### Copy over healthcheck script, make it executable so it can be run.
-####WORKDIR /
-####COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
-####RUN chmod +x sh/healthcheck.sh
-####HEALTHCHECK \
-####    --interval=5s \
-####    --timeout=5s \
-####    --start-period=60s \
-####    --retries=10 \
-####    CMD [ "bash", "sh/healthcheck.sh" ]
+# Copy over healthcheck script, make it executable so it can be run.
+WORKDIR /
+COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
+RUN chmod +x sh/healthcheck.sh
+HEALTHCHECK \
+    --interval=5s \
+    --timeout=5s \
+    --start-period=60s \
+    --retries=10 \
+    CMD [ "bash", "sh/healthcheck.sh" ]
 
-##### Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
-##### behavior of binding to 127.0.0.1 since `aptos` v2.3.2.
-##### This is because the CLI is assumed to not be running inside a container, and
-##### issues can arise on Windows when binding to 0.0.0.0.
-##### See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
-####ENTRYPOINT [ \
-####    "aptos", \
-####    "node", \
-####    "run-localnet", \
-####    "--with-indexer-api", \
-####    "--bind-to", \
-####    "0.0.0.0" \
-####]
+# Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
+# behavior of binding to 127.0.0.1 since `aptos` v2.3.2.
+# This is because the CLI is assumed to not be running inside a container, and
+# issues can arise on Windows when binding to 0.0.0.0.
+# See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
+ENTRYPOINT [ \
+    "aptos", \
+    "node", \
+    "run-localnet", \
+    "--with-indexer-api", \
+    "--bind-to", \
+    "0.0.0.0" \
+]
 
-####STOPSIGNAL SIGKILL
+STOPSIGNAL SIGKILL

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -15,67 +15,67 @@ ARG GIT_TAG="aptos-cli-v$CLI_VERSION"
 
 # Install buildtime dependencies.
 FROM econialabs/rust-builder:$BUILDER_VERSION AS builder
-ARG CARGO_BUILD_JOBS
-ARG CLI_BINARY
-ARG GIT_REPO
-ARG GIT_TAG
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        libudev-dev=252* \
-        build-essential=12* \
-        libclang-dev=1:14* \
-        libpq-dev=15* \
-        libssl-dev=3* \
-        libdw-dev=0.188* \
-        pkg-config=1.8* \
-        lld=1:14* \
-        curl=7* \
-    && rm -rf /var/lib/apt/lists/*
+####ARG CARGO_BUILD_JOBS
+####ARG CLI_BINARY
+####ARG GIT_REPO
+####ARG GIT_TAG
+####RUN apt-get update \
+####    && apt-get install --no-install-recommends -y \
+####        libudev-dev=252* \
+####        build-essential=12* \
+####        libclang-dev=1:14* \
+####        libpq-dev=15* \
+####        libssl-dev=3* \
+####        libdw-dev=0.188* \
+####        pkg-config=1.8* \
+####        lld=1:14* \
+####        curl=7* \
+####    && rm -rf /var/lib/apt/lists/*
 
-# Clone aptos-core, update a known offending dependency, build the CLI binary
-# using specified number of parallel jobs, then strip it.
-RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
-WORKDIR /aptos-core
-RUN cargo update --package time \
-    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
-WORKDIR /
-RUN strip -s "$CLI_BINARY"
+##### Clone aptos-core, update a known offending dependency, build the CLI binary
+##### using specified number of parallel jobs, then strip it.
+####RUN git clone $GIT_REPO --branch $GIT_TAG --depth 1
+####WORKDIR /aptos-core
+####RUN cargo update --package time \
+####    && cargo build --bin aptos --jobs $CARGO_BUILD_JOBS --profile cli
+####WORKDIR /
+####RUN strip -s "$CLI_BINARY"
 
-# Install runtime dependencies, copy over binary.
-FROM debian:bookworm-slim AS runtime
-ARG CLI_BINARY
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        ca-certificates=2023* \
-        curl=7* \
-        git=1:2.39* \
-        jq=1.6* \
-    && rm -rf /var/lib/apt/lists/*
-COPY --from=builder $CLI_BINARY /usr/local/bin
+##### Install runtime dependencies, copy over binary.
+####FROM debian:bookworm-slim AS runtime
+####ARG CLI_BINARY
+####RUN apt-get update \
+####    && apt-get install --no-install-recommends -y \
+####        ca-certificates=2023* \
+####        curl=7* \
+####        git=1:2.39* \
+####        jq=1.6* \
+####    && rm -rf /var/lib/apt/lists/*
+####COPY --from=builder $CLI_BINARY /usr/local/bin
 
-# Copy over healthcheck script, make it executable so it can be run.
-WORKDIR /
-COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
-RUN chmod +x sh/healthcheck.sh
-HEALTHCHECK \
-    --interval=5s \
-    --timeout=5s \
-    --start-period=60s \
-    --retries=10 \
-    CMD [ "bash", "sh/healthcheck.sh" ]
+##### Copy over healthcheck script, make it executable so it can be run.
+####WORKDIR /
+####COPY src/aptos-cli/sh/healthcheck.sh sh/healthcheck.sh
+####RUN chmod +x sh/healthcheck.sh
+####HEALTHCHECK \
+####    --interval=5s \
+####    --timeout=5s \
+####    --start-period=60s \
+####    --retries=10 \
+####    CMD [ "bash", "sh/healthcheck.sh" ]
 
-# Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
-# behavior of binding to 127.0.0.1 since `aptos` v2.3.2.
-# This is because the CLI is assumed to not be running inside a container, and
-# issues can arise on Windows when binding to 0.0.0.0.
-# See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
-ENTRYPOINT [ \
-    "aptos", \
-    "node", \
-    "run-localnet", \
-    "--with-indexer-api", \
-    "--bind-to", \
-    "0.0.0.0" \
-]
+##### Note that the `--bind-to 0.0.0.0` flag is required to undo the default CLI
+##### behavior of binding to 127.0.0.1 since `aptos` v2.3.2.
+##### This is because the CLI is assumed to not be running inside a container, and
+##### issues can arise on Windows when binding to 0.0.0.0.
+##### See: https://github.com/aptos-labs/aptos-core/commit/d8eef35
+####ENTRYPOINT [ \
+####    "aptos", \
+####    "node", \
+####    "run-localnet", \
+####    "--with-indexer-api", \
+####    "--bind-to", \
+####    "0.0.0.0" \
+####]
 
-STOPSIGNAL SIGKILL
+####STOPSIGNAL SIGKILL


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Clean up the Aptos CLI builder so that it does not rely on Docker Hub keys with remove permissions, or passing secrets in a run command

# Testing

- [x] Build and push to Docker Hub per https://github.com/econia-labs/cloud-infra/actions/runs/13125611755

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
