### PR TITLE
[ECO-2758] Revert jq version change back to `1.7`

### DIFF
--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -48,21 +48,18 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates=2023* \
         curl=7* \
-        git=1:2.39* \
-    && rm -rf /var/lib/apt/lists/*
-COPY --from=builder $CLI_BINARY /usr/local/bin
+        git=1:2.39*
 
-# Conditional download based on architecture, since version 1.7 isn't available
-# in apt packages for arm
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Downloading jq for arm64"; \
-        curl -L -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64; \
-    else \
-        echo "Installing jq via apt for amd64"; \
-        apt-get install --no-install-recommends -y jq=1.7*; \
-    fi \
+# Store the jq release page base URL in a variable and interpolate the proper
+# target architecture for `curl`, since `jq-1.7` is not available in the debian
+# `apt` packages.
+RUN BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
+    && curl -L -o /usr/local/bin/jq "${BASE_URL}-${TARGETARCH}" \
     && chmod +x /usr/local/bin/jq \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && jq --version | grep 'jq-1.7'
+
+COPY --from=builder $CLI_BINARY /usr/local/bin
 
 # Copy over healthcheck script, make it executable so it can be run.
 WORKDIR /

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -55,10 +55,19 @@ RUN apt-get update \
 # target architecture for `curl`, since `jq-1.7` is not available in the debian
 # `apt` packages.
 # hadolint ignore=DL4006
-RUN BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
-    && curl -L -o /usr/local/bin/jq "${BASE_URL}-${TARGETARCH}" \
+RUN set -x \
+    && BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
+    && case "${TARGETARCH}" in \
+         "amd64") JQ_ARCH="amd64" ;; \
+         "arm64") JQ_ARCH="arm64" ;; \
+         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+       esac \
+    && FULL_URL="${BASE_URL}-${JQ_ARCH}" \
+    && echo "Attempting to download from: $FULL_URL" \
+    && curl -L -f -o /usr/local/bin/jq "$FULL_URL" \
     && chmod +x /usr/local/bin/jq \
-    && jq --version | grep 'jq-1.7'
+    && echo "File type: $(file /usr/local/bin/jq)" \
+    && /usr/local/bin/jq --version | grep 'jq-1.7'
 
 COPY --from=builder $CLI_BINARY /usr/local/bin
 

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -49,9 +49,20 @@ RUN apt-get update \
         ca-certificates=2023* \
         curl=7* \
         git=1:2.39* \
-        jq=1.7* \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder $CLI_BINARY /usr/local/bin
+
+# Conditional download based on architecture, since version 1.7 isn't available
+# in apt packages for arm
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        echo "Downloading jq for arm64"; \
+        curl -L -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64; \
+    else \
+        echo "Installing jq via apt for amd64"; \
+        apt-get install --no-install-recommends -y jq=1.7*; \
+    fi \
+    && chmod +x /usr/local/bin/jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy over healthcheck script, make it executable so it can be run.
 WORKDIR /

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -48,15 +48,16 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates=2023* \
         curl=7* \
-        git=1:2.39*
+        git=1:2.39* \
+    && rm -rf /var/lib/apt/lists/*
 
 # Store the jq release page base URL in a variable and interpolate the proper
 # target architecture for `curl`, since `jq-1.7` is not available in the debian
 # `apt` packages.
+# hadolint ignore=DL4006
 RUN BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
     && curl -L -o /usr/local/bin/jq "${BASE_URL}-${TARGETARCH}" \
     && chmod +x /usr/local/bin/jq \
-    && rm -rf /var/lib/apt/lists/* \
     && jq --version | grep 'jq-1.7'
 
 COPY --from=builder $CLI_BINARY /usr/local/bin

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -3,7 +3,6 @@
 # cspell:word libpq
 # cspell:word libdw
 # cspell:word localnet
-# cspell:word rustflags
 # cspell:word esac
 
 ARG BUILDER_VERSION=1.1.0

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update \
         ca-certificates=2023* \
         curl=7* \
         git=1:2.39* \
-        jq=1.6* \
+        jq=1.7* \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder $CLI_BINARY /usr/local/bin
 

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -4,6 +4,7 @@
 # cspell:word libdw
 # cspell:word localnet
 # cspell:word rustflags
+# cspell:word esac
 
 ARG BUILDER_VERSION=1.1.0
 # Default to compile using as many logical CPUs as possible.

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -55,19 +55,16 @@ RUN apt-get update \
 # target architecture for `curl`, since `jq-1.7` is not available in the debian
 # `apt` packages.
 # hadolint ignore=DL4006
-RUN set -x \
-    && BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
-    && case "${TARGETARCH}" in \
-         "amd64") JQ_ARCH="amd64" ;; \
-         "arm64") JQ_ARCH="arm64" ;; \
-         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+RUN BASE_URL="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux" \
+    && ARCH=$(uname -m) \
+    && case "${ARCH}" in \
+         "x86_64") JQ_ARCH="amd64" ;; \
+         "aarch64") JQ_ARCH="arm64" ;; \
+         *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
        esac \
-    && FULL_URL="${BASE_URL}-${JQ_ARCH}" \
-    && echo "Attempting to download from: $FULL_URL" \
-    && curl -L -f -o /usr/local/bin/jq "$FULL_URL" \
+    && curl -L -o /usr/local/bin/jq "${BASE_URL}-${JQ_ARCH}" \
     && chmod +x /usr/local/bin/jq \
-    && echo "File type: $(file /usr/local/bin/jq)" \
-    && /usr/local/bin/jq --version | grep 'jq-1.7'
+    && jq --version | grep 'jq-1.7'
 
 COPY --from=builder $CLI_BINARY /usr/local/bin
 


### PR DESCRIPTION
# Description

Revert the `jq` version change back to `1.7`, it was inadvertently changed in https://github.com/econia-labs/cloud-infra/pull/20, it causes parsing errors in the deployer setup scripts

I see why it was downgraded now, debian doesn't have it available in the apt packages
- [x] Download it from the github releases directly for both architectures, per https://github.com/jqlang/jq/pull/2884