### PR TITLE
ci(ECO-2997): Add code owners validation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-.github/ @alnoki
-.gitignore @alnoki
-CONTRIBUTING.MD     @alnoki
-LICENSE.MD          @alnoki
-README.md           @alnoki
-cfg/ @alnoki
-doc/ @alnoki
-src/ @alnoki
+.github/        @alnoki
+.gitignore      @alnoki
+CONTRIBUTING.MD @alnoki
+LICENSE.MD      @alnoki
+README.md       @alnoki
+cfg/            @alnoki
+doc/            @alnoki
+src/            @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@ LICENSE.MD      @alnoki
 README.md       @alnoki
 cfg/            @alnoki
 doc/            @alnoki
-src/             @alnoki
+src/            @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+.github/ @alnoki
+cfg/ @alnoki
+doc/ @alnoki
+src/ @alnoki
+.gitignore @alnoki
+CONTRIBUTING.md @alnoki
+LICENSE.md @alnoki
+README.md @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 .gitignore      @alnoki
 CONTRIBUTING.MD @alnoki
 LICENSE.MD      @alnoki
-README.md       @alnoki
 cfg/            @alnoki
 doc/            @alnoki
 src/            @alnoki
+README.md       @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 .github/ @alnoki
+.gitignore @alnoki
+CONTRIBUTING.md     @alnoki
+LICENSE.md          @alnoki
+README.md           @alnoki
 cfg/ @alnoki
 doc/ @alnoki
 src/ @alnoki
-.gitignore @alnoki
-CONTRIBUTING.md @alnoki
-LICENSE.md @alnoki
-README.md @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 .gitignore      @alnoki
 CONTRIBUTING.MD @alnoki
 LICENSE.MD      @alnoki
+README.md       @alnoki
 cfg/            @alnoki
 doc/            @alnoki
 src/            @alnoki
-README.md       @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 .github/ @alnoki
 .gitignore @alnoki
-CONTRIBUTING.md     @alnoki
-LICENSE.md          @alnoki
+CONTRIBUTING.MD     @alnoki
+LICENSE.MD          @alnoki
 README.md           @alnoki
 cfg/ @alnoki
 doc/ @alnoki

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@ LICENSE.MD      @alnoki
 README.md       @alnoki
 cfg/            @alnoki
 doc/            @alnoki
-src/            @alnoki
+src/             @alnoki

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -14,7 +14,9 @@ runs:
     id: 'verify-codeowners-exists'
     run: 'sh ${{ github.action_path }}/sh/verify-codeowners-exists.sh'
     shell: 'sh'
-  - uses: 'mszostok/codeowners-validator@v0.7.4'
+  - env:
+      GH_TOKEN: '${{ github.token }}'
+    uses: 'mszostok/codeowners-validator@v0.7.4'
     with:
       experimental_checks: 'avoid-shadowing,notowned'
       github_access_token: '${{ inputs.github_access_token }}'

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -25,5 +25,13 @@ runs:
     with:
       file-path: '.github/CODEOWNERS'
       remove-empty-lines: 'true'
+  - name: 'Set up Python to enable pre-commit'
+    uses: 'actions/setup-python@v5'
+    with:
+      python-version: '3.13'
+  - name: 'Sort CODEOWNERS using pre-commit'
+    uses: 'pre-commit/action@v3.0.1'
+    with:
+      extra_args: '--all-files --config ${{ github.action_path }}/cfg/pre-commit-config.yaml --files .github/CODEOWNERS --verbose'
   using: 'composite'
 ...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -16,6 +16,11 @@ runs:
     uses: 'actions/setup-python@v5'
     with:
       python-version: '3.13'
+  - env:
+      CODEOWNERS_PATH: '.github/CODEOWNERS'
+    id: 'verify-codeowners-exists'
+    run: 'sh ${{ github.action_path }}/sh/verify-codeowners-exists.sh'
+    shell: 'sh'
   - name: 'Sort CODEOWNERS using pre-commit'
     uses: 'pre-commit/action@v3.0.1'
     with:
@@ -23,11 +28,6 @@ runs:
         --config ${{ github.action_path }}/cfg/pre-commit-config.yaml
         --files .github/CODEOWNERS
         --verbose
-  - env:
-      CODEOWNERS_PATH: '.github/CODEOWNERS'
-    id: 'verify-codeowners-exists'
-    run: 'sh ${{ github.action_path }}/sh/verify-codeowners-exists.sh'
-    shell: 'sh'
   - uses: 'mszostok/codeowners-validator@v0.7.4'
     with:
       experimental_checks: 'avoid-shadowing,notowned'

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -32,11 +32,9 @@ runs:
   - name: 'Sort CODEOWNERS using pre-commit'
     uses: 'pre-commit/action@v3.0.1'
     with:
-      extra_args:
-      - '--config'
-      - '${{ github.action_path }}/cfg/pre-commit-config.yaml'
-      - '--files'
-      - '.github/CODEOWNERS'
-      - '--verbose'
+      extra_args: >-
+        --config ${{ github.action_path }}/cfg/pre-commit-config.yaml
+        --files .github/CODEOWNERS
+        --verbose
   using: 'composite'
 ...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -12,6 +12,17 @@ name: 'Code owners'
 runs:
   steps:
   - uses: 'actions/checkout@v4'
+  - name: 'Set up Python to enable pre-commit'
+    uses: 'actions/setup-python@v5'
+    with:
+      python-version: '3.13'
+  - name: 'Sort CODEOWNERS using pre-commit'
+    uses: 'pre-commit/action@v3.0.1'
+    with:
+      extra_args: >-
+        --config ${{ github.action_path }}/cfg/pre-commit-config.yaml
+        --files .github/CODEOWNERS
+        --verbose
   - env:
       CODEOWNERS_PATH: '.github/CODEOWNERS'
     id: 'verify-codeowners-exists'
@@ -25,16 +36,5 @@ runs:
     with:
       file-path: '.github/CODEOWNERS'
       remove-empty-lines: 'true'
-  - name: 'Set up Python to enable pre-commit'
-    uses: 'actions/setup-python@v5'
-    with:
-      python-version: '3.13'
-  - name: 'Sort CODEOWNERS using pre-commit'
-    uses: 'pre-commit/action@v3.0.1'
-    with:
-      extra_args: >-
-        --config ${{ github.action_path }}/cfg/pre-commit-config.yaml
-        --files .github/CODEOWNERS
-        --verbose
   using: 'composite'
 ...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -14,9 +14,7 @@ runs:
     id: 'verify-codeowners-exists'
     run: 'sh ${{ github.action_path }}/sh/verify-codeowners-exists.sh'
     shell: 'sh'
-  - env:
-      GH_TOKEN: '${{ github.token }}'
-    uses: 'mszostok/codeowners-validator@v0.7.4'
+  - uses: 'mszostok/codeowners-validator@v0.7.4'
     with:
       experimental_checks: 'avoid-shadowing,notowned'
       github_access_token: '${{ inputs.github_access_token }}'

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -32,6 +32,6 @@ runs:
   - name: 'Sort CODEOWNERS using pre-commit'
     uses: 'pre-commit/action@v3.0.1'
     with:
-      extra_args: '--all-files --config ${{ github.action_path }}/cfg/pre-commit-config.yaml --files .github/CODEOWNERS --verbose'
+      extra_args: ' --config ${{ github.action_path }}/cfg/pre-commit-config.yaml --files .github/CODEOWNERS --verbose'
   using: 'composite'
 ...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -32,6 +32,11 @@ runs:
   - name: 'Sort CODEOWNERS using pre-commit'
     uses: 'pre-commit/action@v3.0.1'
     with:
-      extra_args: ' --config ${{ github.action_path }}/cfg/pre-commit-config.yaml --files .github/CODEOWNERS --verbose'
+      extra_args:
+      - '--config'
+      - '${{ github.action_path }}/cfg/pre-commit-config.yaml'
+      - '--files'
+      - '.github/CODEOWNERS'
+      - '--verbose'
   using: 'composite'
 ...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -1,0 +1,26 @@
+---
+author: 'Econia Labs'
+description: 'Validate code owners'
+inputs:
+  github_access_token:
+    description: 'GitHub personal (classic) access token with read:org scope'
+    required: true
+name: 'Code owners'
+runs:
+  steps:
+  - uses: 'actions/checkout@v4'
+  - env:
+      CODEOWNERS_PATH: '.github/CODEOWNERS'
+    id: 'verify-codeowners-exists'
+    run: 'sh ${{ github.action_path }}/sh/verify-codeowners-exists.sh'
+    shell: 'sh'
+  - uses: 'mszostok/codeowners-validator@v0.7.4'
+    with:
+      experimental_checks: 'avoid-shadowing,notowned'
+      github_access_token: '${{ inputs.github_access_token }}'
+  - uses: 'Archetypically/format-codeowners@v1'
+    with:
+      file-path: '.github/CODEOWNERS'
+      remove-empty-lines: 'true'
+  using: 'composite'
+...

--- a/.github/actions/codeowners/action.yaml
+++ b/.github/actions/codeowners/action.yaml
@@ -1,3 +1,6 @@
+# cspell:word archetypically
+# cspell:word mszostok
+# cspell:word notowned
 ---
 author: 'Econia Labs'
 description: 'Validate code owners'

--- a/.github/actions/codeowners/cfg/pre-commit-config.yaml
+++ b/.github/actions/codeowners/cfg/pre-commit-config.yaml
@@ -1,9 +1,7 @@
 ---
 repos:
 - hooks:
-  - args:
-    - '--check-only'
-    files: '.github/CODEOWNERS'
+  - files: '.github/CODEOWNERS'
     id: 'file-contents-sorter'
   repo: 'https://github.com/pre-commit/pre-commit-hooks'
   rev: 'v5.0.0'

--- a/.github/actions/codeowners/cfg/pre-commit-config.yaml
+++ b/.github/actions/codeowners/cfg/pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: file-contents-sorter
+  - files: '.github/CODEOWNERS'

--- a/.github/actions/codeowners/cfg/pre-commit-config.yaml
+++ b/.github/actions/codeowners/cfg/pre-commit-config.yaml
@@ -1,6 +1,8 @@
+---
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-  - id: file-contents-sorter
+- hooks:
+  - id: 'file-contents-sorter'
   - files: '.github/CODEOWNERS'
+  repo: 'https://github.com/pre-commit/pre-commit-hooks'
+  rev: 'v5.0.0'
+...

--- a/.github/actions/codeowners/cfg/pre-commit-config.yaml
+++ b/.github/actions/codeowners/cfg/pre-commit-config.yaml
@@ -1,7 +1,9 @@
 ---
 repos:
 - hooks:
-  - files: '.github/CODEOWNERS'
+  - args:
+    - '--check-only'
+    files: '.github/CODEOWNERS'
     id: 'file-contents-sorter'
   repo: 'https://github.com/pre-commit/pre-commit-hooks'
   rev: 'v5.0.0'

--- a/.github/actions/codeowners/cfg/pre-commit-config.yaml
+++ b/.github/actions/codeowners/cfg/pre-commit-config.yaml
@@ -1,8 +1,8 @@
 ---
 repos:
 - hooks:
-  - id: 'file-contents-sorter'
   - files: '.github/CODEOWNERS'
+    id: 'file-contents-sorter'
   repo: 'https://github.com/pre-commit/pre-commit-hooks'
   rev: 'v5.0.0'
 ...

--- a/.github/actions/codeowners/sh/verify-codeowners-exists.sh
+++ b/.github/actions/codeowners/sh/verify-codeowners-exists.sh
@@ -1,0 +1,3 @@
+if [ ! -f .github/CODEOWNERS ]; then
+    exit 1
+fi

--- a/.github/actions/codeowners/sh/verify-codeowners-exists.sh
+++ b/.github/actions/codeowners/sh/verify-codeowners-exists.sh
@@ -1,4 +1,5 @@
+#!/bin/sh
 if [ ! -f .github/CODEOWNERS ]; then
-    echo "::error::CODEOWNERS file not found at .github/CODEOWNERS"
-    exit 1
+	echo "::error::CODEOWNERS file not found at .github/CODEOWNERS"
+	exit 1
 fi

--- a/.github/actions/codeowners/sh/verify-codeowners-exists.sh
+++ b/.github/actions/codeowners/sh/verify-codeowners-exists.sh
@@ -1,3 +1,4 @@
 if [ ! -f .github/CODEOWNERS ]; then
+    echo "::error::CODEOWNERS file not found at .github/CODEOWNERS"
     exit 1
 fi

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: 'econia-labs/common/.github/actions/codeowners@ECO-2997'
       with:
-        github_access_token: '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
+        github_access_token: '${{ secrets.CODEOWNER_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
 name: 'Code owners'
 'on':
   merge_group: null

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -11,5 +11,4 @@ name: 'Code owners'
 'on':
   merge_group: null
   pull_request: null
-  pull_request_review: null
 ...

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -4,7 +4,7 @@ jobs:
     name: 'Code owners'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'econia-labs/common/.github/actions/codeowners@ECO-2997'
+    - uses: 'econia-labs/common/.github/actions/codeowners@main'
       with:
         github_access_token: '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_TOKEN }}'
 name: 'Code owners'

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: 'econia-labs/common/.github/actions/codeowners@ECO-2997'
       with:
-        github_access_token: '${{ secrets.CODEOWNER_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
+        github_access_token: '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_TOKEN }}'
 name: 'Code owners'
 'on':
   merge_group: null

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -6,8 +6,7 @@ jobs:
     steps:
     - uses: 'econia-labs/common/.github/actions/codeowners@ECO-2997'
       with:
-        github_access_token:
-          '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
+        github_access_token: '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
 name: 'Code owners'
 'on':
   merge_group: null

--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -1,0 +1,16 @@
+---
+jobs:
+  pr-size:
+    name: 'Code owners'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'econia-labs/common/.github/actions/codeowners@ECO-2997'
+      with:
+        github_access_token:
+          '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_ACCESS_TOKEN }}'
+name: 'Code owners'
+'on':
+  merge_group: null
+  pull_request: null
+  pull_request_review: null
+...

--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -1,8 +1,10 @@
+alnoki
 aptos
 awslogs
 awsvpc
 buildx
 chainguard
+codeowners
 dockerhub
 econia
 econialabs


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add an abstracted GitHub action and calling workflow to validate that:

1. There exists a code owners file at `.github/CODEOWNERS`.
1. `CODEOWNERS` has full coverage with legitimate users.
1. `CODEOWNERS` is sorted and formatted.

# Testing

Assorted testing on this branch, note that the check passes for the third-to-last commit.

The second-to-last commit, which invalidates the check, is a single change for the branch name to remove the requirement for a followup PR.

The final commit simply removes the pull request review trigger.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
