### PR TITLE
chore(ECO-3252): Update rust builder rust version

### DIFF
--- a/src/rust-builder/Dockerfile
+++ b/src/rust-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84.1-slim-bookworm
+FROM rust:1.86.0-slim-bookworm
 RUN cargo install cargo-chef@0.1.71
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=1:2.39.5* \

--- a/src/rust-builder/template.Dockerfile
+++ b/src/rust-builder/template.Dockerfile
@@ -1,6 +1,6 @@
 # Chainguard image digest (SHA-256), Rust builder version.
 ARG DIGEST=c907cf5576de12bb54ac2580a91d0287de55f56bce4ddd66a0edf5ebaba9feed
-ARG BUILDER_VERSION=1.1.0
+ARG BUILDER_VERSION=1.2.0
 
 FROM econialabs/rust-builder:$BUILDER_VERSION AS base
 WORKDIR /app


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR updates the rust version of the rust builder to the latest stable version.

Multiple features have been introduced since the last update, including stable async closures, which are required to build the new processor without using nightly.